### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+---
+language: c
+
+before_install:
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get install -qq lib32z1
+
+script: "cd TinyG2 && make"
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 g2 - happy happy joy joy
 ========================
+
+[![Build Status](https://travis-ci.org/synthetos/g2.svg)](https://travis-ci.org/synthetos/g2)


### PR DESCRIPTION
This CL adds a continuous build config to the G2 repository. It will look like https://travis-ci.org/krasin/g2 but the address will be a bit different: https://travis-ci.org/synthetos/g2

One will have to activate Travis CI for g2 repository, preferably before merging this CL (to have a "green" build w/o waiting for the next commit). To activate it:
1. Go to https://travis-ci.org/profile
2. Press "sync now" button
3. Turn on Travis CI on G2 repository

After that, please, merge this CL.
