### PR TITLE
Update tools directory makefile to handle bad cert when downloading gcc.

### DIFF
--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -5,10 +5,17 @@ ARCH ?= gcc-arm-none-eabi
 ifeq ($(ARCH), gcc-arm-none-eabi)
 TOOLS_SUBPATH = gcc-arm-none-eabi
 
-TOOLS_VERSION_SHORT = 4.8
-TOOLS_VERSION_LONG = 4.8-2014-q1-update
-TOOLS_VERSION_FILENAME = 4_8-2014q1-20140314
-TOOLS_EXPANDED_DIRNAME = gcc-arm-none-eabi-4_8-2014q1
+TOOLS_VERSION_SHORT = 4.9
+TOOLS_VERSION_LONG = 4.9-2014-q4-major
+TOOLS_VERSION_FILENAME = 4_9-2014q4-20141203
+TOOLS_EXPANDED_DIRNAME = gcc-arm-none-eabi-4_9-2014q4
+
+#https://launchpad.net/gcc-arm-embedded/4.9/4.9-2014-q4-major/+download/gcc-arm-none-eabi-4_9-2014q4-20141203-linux.tar.bz2
+# I had to install the following to get this to run
+# sudo apt-get install python-serial python-argparse openocd \
+#    flex bison libncurses5-dev autoconf texinfo build-essential \
+#    libftdi-dev libtool zlib1g-dev genromfs git-core wget zip
+# sudo apt-get install libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386
 
 TOOLS_URL_PREFIX = https://launchpad.net/gcc-arm-embedded/${TOOLS_VERSION_SHORT}/${TOOLS_VERSION_LONG}/+download/
 TOOLS_OSX_ARCHIVE_FILENAME = gcc-arm-none-eabi-${TOOLS_VERSION_FILENAME}-mac.tar.bz2
@@ -29,7 +36,7 @@ DOWNLOAD_TOOL = curl -OL
 else
 ifeq (Linux,${UNAME})
 OS = LINUX
-DOWNLOAD_TOOL = wget
+DOWNLOAD_TOOL = wget --no-check-certificate
 endif #LINUX
 endif #Darwin
 


### PR DESCRIPTION
I had some issues getting the edge branch to build. It appears there is a bad cert on launchpad.net which prevents you from downloading the arm compiler. I removed the cert check and updated to the more recent version of the compiler. I also added a note about the tools I needed on linux to get this to run. This should probably go into the readme. 
