### PR TITLE
Add support for tool length offsets (G10 L1/G10 L10/G43/G49)

### DIFF
--- a/TinyG2/canonical_machine.cpp
+++ b/TinyG2/canonical_machine.cpp
@@ -295,7 +295,7 @@ float cm_get_active_coord_offset(const uint8_t axis)
     if (cm.gm.absolute_override == ABSOLUTE_OVERRIDE_ON) {  // no offset if in absolute override mode
         return (0.0);
     }
-    float offset = cm.offset[cm.gm.coord_system][axis];
+    float offset = cm.offset[cm.gm.coord_system][axis] + cm.tl_offset[axis];
     if (cm.gmx.origin_offset_enable == true) {
         offset += cm.gmx.origin_offset[axis];               // includes G5x and G92 components
     }
@@ -879,7 +879,7 @@ stat_t cm_set_arc_distance_mode(const uint8_t mode)
 }
 
 /*
- * cm_set_coord_offsets() - G10 L2/L20 Pn (affects MODEL only)
+ * cm_set_coord_offsets() - G10 L1/L2/L10/L20 Pn (affects MODEL only)
  *
  *	This function applies the offset to the GM model but does not persist the offsets
  *	during the Gcode cycle. The persist flag is used to persist offsets once the cycle
@@ -893,35 +893,129 @@ stat_t cm_set_coord_offsets(const uint8_t coord_system,
                             const uint8_t L_word,
                             const float offset[], const bool flag[])
 {
-	if ((coord_system < G54) || (coord_system > COORD_SYSTEM_MAX)) {	// you can't set G53
-		return (STAT_P_WORD_IS_INVALID);
-	}
     if (!cm.gf.L_word) {
 		return (STAT_L_WORD_IS_MISSING);
     }
-    if ((L_word != 2) && (L_word != 20)) {
-		return (STAT_L_WORD_IS_INVALID);
-    }
-	for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
-		if (flag[axis]) {
-            if (L_word == 2) {
-    			cm.offset[coord_system][axis] = _to_millimeters(offset[axis]);
-            } else {
-    			cm.offset[coord_system][axis] = cm.gmx.position[axis] - _to_millimeters(offset[axis]);
+
+    if ((L_word == 2) || (L_word == 20)) {
+        // coordinate system offset command
+        if ((coord_system < G54) || (coord_system > COORD_SYSTEM_MAX)) {
+            // you can't set G53
+            return (STAT_P_WORD_IS_INVALID);
+        }
+
+        for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+            if (flag[axis]) {
+                if (L_word == 2) {
+                    cm.offset[coord_system][axis] = _to_millimeters(offset[axis]);
+                } else {
+                    // Should L20 take into account G92 offsets?
+                    cm.offset[coord_system][axis] = 
+                        cm.gmx.position[axis]
+                        - _to_millimeters(offset[axis])
+                        - cm.tl_offset[axis];
+                }
+
+                // persist offsets once machining cycle is over
+                cm.deferred_write_flag = true;
             }
-			cm.deferred_write_flag = true;                  // persist offsets once machining cycle is over
-		}
-	}
-	return (STAT_OK);
+        }
+    }
+    else if ((L_word == 1) || (L_word == 10)) {
+        // tool table offset command. L11 not supported atm.
+        if ((coord_system < 1) || (coord_system > TOOLS)) {
+            return (STAT_P_WORD_IS_INVALID);
+        }
+
+        for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+            if (flag[axis]) {
+                if (L_word == 1) {
+                    cm.tt_offset[coord_system][axis] = _to_millimeters(offset[axis]);
+                } else {
+                    // L10 should also take into account G92 offset
+                    cm.tt_offset[coord_system][axis] = 
+                        cm.gmx.position[axis]
+                        - _to_millimeters(offset[axis])
+                        - cm.offset[cm.gm.coord_system][axis]
+                        -(cm.gmx.origin_offset[axis] * cm.gmx.origin_offset_enable);
+                }
+
+                // persist offsets once machining cycle is over
+                cm.deferred_write_flag = true;
+            }
+        }
+    }
+    else {
+        return (STAT_L_WORD_IS_INVALID);
+    }
+    return (STAT_OK);
 }
 
 /******************************************************************************************
  * Representation functions that affect gcode model and are queued to planner (synchronous)
  */
 /*
+ * cm_set_tl_offset() - G43
  * cm_set_coord_system() - G54-G59
  * _exec_offset() - callback from planner
  */
+
+stat_t cm_set_tl_offset(const uint8_t H_word, bool apply_additional)
+{
+    uint8_t tool;
+    if (cm.gf.H_word)
+    {
+        if (cm.gn.H_word > TOOLS)
+        {
+            return (STAT_H_WORD_IS_INVALID);
+        }
+        if (cm.gn.H_word == 0)
+        {
+            // interpret H0 as "current tool", just like no H at all.
+            tool = cm.gm.tool;
+        }
+        else
+        {
+            tool = cm.gn.H_word;
+        }
+    }
+    else
+    {
+        tool = cm.gm.tool;
+    }
+
+    if (apply_additional)
+    {
+        for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+            cm.tl_offset[axis] += cm.tt_offset[tool][axis];
+        }
+    }
+    else
+    {
+        for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+            cm.tl_offset[axis] = cm.tt_offset[tool][axis];
+        }
+    }
+
+    float value[] = { (float)cm.gm.coord_system,0,0,0,0,0 };	    // pass coordinate system in value[0] element
+    bool flags[]  = { 1,0,0,0,0,0 };
+    mp_queue_command(_exec_offset, value, flags);			// second vector (flags) is not used, so fake it
+    return (STAT_OK);
+}
+
+stat_t cm_cancel_tl_offset()
+{
+    for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+        cm.tl_offset[axis] = 0;
+    }
+
+    float value[] = { (float)cm.gm.coord_system,0,0,0,0,0 };	    // pass coordinate system in value[0] element
+    bool flags[]  = { 1,0,0,0,0,0 };
+    mp_queue_command(_exec_offset, value, flags);			// second vector (flags) is not used, so fake it
+    return (STAT_OK);
+}
+
+
 stat_t cm_set_coord_system(const uint8_t coord_system)
 {
     cm.gm.coord_system = (cmCoordSystem)coord_system;
@@ -937,7 +1031,7 @@ static void _exec_offset(float *value, bool *flag)
 	uint8_t coord_system = ((uint8_t)value[0]);				// coordinate system is passed in value[0] element
 	float offsets[AXES];
 	for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
-		offsets[axis] = cm.offset[coord_system][axis] + (cm.gmx.origin_offset[axis] * cm.gmx.origin_offset_enable);
+		offsets[axis] = cm.offset[coord_system][axis] + cm.tl_offset[axis] + (cm.gmx.origin_offset[axis] * cm.gmx.origin_offset_enable);
 	}
 	mp_set_runtime_work_offset(offsets);
 	cm_set_work_offsets(MODEL);								// set work offsets in the Gcode model
@@ -1031,7 +1125,9 @@ stat_t cm_set_origin_offsets(const float offset[], const bool flag[])
 	for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
 		if (flag[axis]) {
 			cm.gmx.origin_offset[axis] = cm.gmx.position[axis] -
-	            cm.offset[cm.gm.coord_system][axis] - _to_millimeters(offset[axis]);
+                            cm.offset[cm.gm.coord_system][axis] - 
+                            cm.tl_offset[axis] -
+                            _to_millimeters(offset[axis]);
 		}
 	}
 	// now pass the offset to the callback - setting the coordinate system also applies the offsets
@@ -2003,6 +2099,14 @@ stat_t cm_get_ofs(nvObj_t *nv)
 	return (STAT_OK);
 }
 
+stat_t cm_get_tof(nvObj_t *nv)
+{
+    nv->value = cm.tl_offset[_get_axis(nv->index)];
+    nv->precision = GET_TABLE_WORD(precision);
+    nv->valuetype = TYPE_FLOAT;
+    return (STAT_OK);
+}
+
 /*
  * AXIS GET AND SET FUNCTIONS
  *
@@ -2236,6 +2340,7 @@ const char fmt_g92e[] PROGMEM = "G92 enabled          %d\n";
 const char fmt_pos[] PROGMEM = "%c position:%15.3f%s\n";
 const char fmt_mpo[] PROGMEM = "%c machine posn:%11.3f%s\n";
 const char fmt_ofs[] PROGMEM = "%c work offset:%12.3f%s\n";
+const char fmt_tof[] PROGMEM = "%c tool length offset:%12.3f%s\n";
 const char fmt_hom[] PROGMEM = "%c axis homing state:%2.0f\n";
 
 const char fmt_gpl[] PROGMEM = "[gpl] default gcode plane%10d [0=G17,1=G18,2=G19]\n";
@@ -2409,6 +2514,7 @@ void cm_print_cpos(nvObj_t *nv) { _print_axis_coord_flt(nv, fmt_cpos);}
 void cm_print_pos(nvObj_t *nv) { _print_pos(nv, fmt_pos, cm_get_units_mode(MODEL));}
 void cm_print_mpo(nvObj_t *nv) { _print_pos(nv, fmt_mpo, MILLIMETERS);}
 void cm_print_ofs(nvObj_t *nv) { _print_pos(nv, fmt_ofs, MILLIMETERS);}
+void cm_print_tof(nvObj_t *nv) { _print_pos(nv, fmt_tof, MILLIMETERS);}
 void cm_print_hom(nvObj_t *nv) { _print_hom(nv, fmt_hom);}
 
 #endif // __TEXT_MODE

--- a/TinyG2/config_app.cpp
+++ b/TinyG2/config_app.cpp
@@ -153,6 +153,13 @@ const cfgItem_t cfgArray[] PROGMEM = {
 	{ "ofs","ofsb",_f0, 3, cm_print_ofs, cm_get_ofs, set_nul,(float *)&cs.null, 0 },			// B work offset
 	{ "ofs","ofsc",_f0, 3, cm_print_ofs, cm_get_ofs, set_nul,(float *)&cs.null, 0 },			// C work offset
 
+	{ "tof","tofx",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// X tool offset
+	{ "tof","tofy",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// Y tool offset
+	{ "tof","tofz",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// Z tool offset
+	{ "tof","tofa",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// A tool offset
+	{ "tof","tofb",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// B tool offset
+	{ "tof","tofc",_f0, 3, cm_print_tof, cm_get_tof, set_nul,(float *)&cs.null, 0 },			// C tool offset
+
 	{ "hom","home",_f0, 0, cm_print_home,cm_get_home,set_01,(float *)&cm.homing_state, 0 },	    // homing state, invoke homing cycle
 	{ "hom","homx",_f0, 0, cm_print_hom, get_ui8, set_01, (float *)&cm.homed[AXIS_X], false },	// X homed - Homing status group
 	{ "hom","homy",_f0, 0, cm_print_hom, get_ui8, set_01, (float *)&cm.homed[AXIS_Y], false },	// Y homed
@@ -447,6 +454,57 @@ const cfgItem_t cfgArray[] PROGMEM = {
 	{ "g59","g59b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.offset[G59][AXIS_B], G59_B_OFFSET },
 	{ "g59","g59c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.offset[G59][AXIS_C], G59_C_OFFSET },
 
+	// Default values for current tool length offsets (not configurable, set to zero)
+	{ "tl","tlx",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_X], 0 },
+	{ "tl","tly",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Y], 0 },
+	{ "tl","tlz",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Z], 0 },
+	{ "tl","tla",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_A], 0 },
+	{ "tl","tlb",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_B], 0 },
+	{ "tl","tlc",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_C], 0 },
+
+	// Tool table offsets
+	{ "tt1","tt1x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[1][AXIS_X], TT1_X_OFFSET },
+	{ "tt1","tt1y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[1][AXIS_Y], TT1_Y_OFFSET },
+	{ "tt1","tt1z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[1][AXIS_Z], TT1_Z_OFFSET },
+	{ "tt1","tt1a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[1][AXIS_A], TT1_A_OFFSET },
+	{ "tt1","tt1b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[1][AXIS_B], TT1_B_OFFSET },
+	{ "tt1","tt1c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[1][AXIS_C], TT1_C_OFFSET },
+
+	{ "tt2","tt2x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[2][AXIS_X], TT2_X_OFFSET },
+	{ "tt2","tt2y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[2][AXIS_Y], TT2_Y_OFFSET },
+	{ "tt2","tt2z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[2][AXIS_Z], TT2_Z_OFFSET },
+	{ "tt2","tt2a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[2][AXIS_A], TT2_A_OFFSET },
+	{ "tt2","tt2b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[2][AXIS_B], TT2_B_OFFSET },
+	{ "tt2","tt2c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[2][AXIS_C], TT2_C_OFFSET },
+
+	{ "tt3","tt3x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[3][AXIS_X], TT3_X_OFFSET },
+	{ "tt3","tt3y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[3][AXIS_Y], TT3_Y_OFFSET },
+	{ "tt3","tt3z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[3][AXIS_Z], TT3_Z_OFFSET },
+	{ "tt3","tt3a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[3][AXIS_A], TT3_A_OFFSET },
+	{ "tt3","tt3b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[3][AXIS_B], TT3_B_OFFSET },
+	{ "tt3","tt3c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[3][AXIS_C], TT1_C_OFFSET },
+
+	{ "tt4","tt4x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[4][AXIS_X], TT4_X_OFFSET },
+	{ "tt4","tt4y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[4][AXIS_Y], TT4_Y_OFFSET },
+	{ "tt4","tt4z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[4][AXIS_Z], TT4_Z_OFFSET },
+	{ "tt4","tt4a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[4][AXIS_A], TT4_A_OFFSET },
+	{ "tt4","tt4b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[4][AXIS_B], TT4_B_OFFSET },
+	{ "tt4","tt4c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[4][AXIS_C], TT4_C_OFFSET },
+
+	{ "tt5","tt5x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[5][AXIS_X], TT5_X_OFFSET },
+	{ "tt5","tt5y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[5][AXIS_Y], TT5_Y_OFFSET },
+	{ "tt5","tt5z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[5][AXIS_Z], TT5_Z_OFFSET },
+	{ "tt5","tt5a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[5][AXIS_A], TT5_A_OFFSET },
+	{ "tt5","tt5b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[5][AXIS_B], TT5_B_OFFSET },
+	{ "tt5","tt5c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[5][AXIS_C], TT5_C_OFFSET },
+
+	{ "tt6","tt6x",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[6][AXIS_X], TT6_X_OFFSET },
+	{ "tt6","tt6y",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[6][AXIS_Y], TT6_Y_OFFSET },
+	{ "tt6","tt6z",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tt_offset[6][AXIS_Z], TT6_Z_OFFSET },
+	{ "tt6","tt6a",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[6][AXIS_A], TT6_A_OFFSET },
+	{ "tt6","tt6b",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[6][AXIS_B], TT6_B_OFFSET },
+	{ "tt6","tt6c",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tt_offset[6][AXIS_C], TT6_C_OFFSET },
+
 	{ "g92","g92x",_fic, 3, cm_print_cofs, get_flt, set_nul,(float *)&cm.gmx.origin_offset[AXIS_X], 0 },// G92 handled differently
 	{ "g92","g92y",_fic, 3, cm_print_cofs, get_flt, set_nul,(float *)&cm.gmx.origin_offset[AXIS_Y], 0 },
 	{ "g92","g92z",_fic, 3, cm_print_cofs, get_flt, set_nul,(float *)&cm.gmx.origin_offset[AXIS_Z], 0 },
@@ -739,6 +797,13 @@ const cfgItem_t cfgArray[] PROGMEM = {
 	{ "","g57",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },
 	{ "","g58",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },
 	{ "","g59",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },
+	{ "","tl",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tl offsets
+	{ "","tt1",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
+	{ "","tt2",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
+	{ "","tt3",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
+	{ "","tt4",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
+	{ "","tt5",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
+	{ "","tt6",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tt offsets
 	{ "","g92",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// origin offsets
 	{ "","g28",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// g28 home position
 	{ "","g30",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// g30 home position
@@ -746,6 +811,7 @@ const cfgItem_t cfgArray[] PROGMEM = {
 	{ "","mpo",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// machine position group
 	{ "","pos",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// work position group
 	{ "","ofs",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// work offset group
+	{ "","tof",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// tool length offset group
 	{ "","hom",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// axis homing state group
 	{ "","prb",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// probing state group
 	{ "","jog",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },	// axis jogging state group
@@ -780,7 +846,7 @@ const cfgItem_t cfgArray[] PROGMEM = {
 /***** Make sure these defines line up with any changes in the above table *****/
 
 #define NV_COUNT_UBER_GROUPS 	5 		// count of uber-groups, above
-#define STANDARD_GROUPS 		38		// count of standard groups, excluding diagnostic and user data groups
+#define STANDARD_GROUPS 		45		// count of standard groups, excluding diagnostic and user data groups
 
 #if (MOTORS >= 5)
 #define MOTOR_GROUP_5			1
@@ -929,7 +995,7 @@ static stat_t _do_axes(nvObj_t *nv)	// print parameters for all axis groups
 
 static stat_t _do_offsets(nvObj_t *nv)	// print offset parameters for G54-G59,G92, G28, G30
 {
-	char list[][TOKEN_LEN+1] = {"g54","g55","g56","g57","g58","g59","g92","g28","g30",""}; // must have a terminating element
+    char list[][TOKEN_LEN+1] = {"g54","g55","g56","g57","g58","g59","g92","g28","g30","tl","tt1","tt2","tt3","tt4","tt5","tt6",""}; // must have a terminating element
 	return (_do_group_list(nv, list));
 }
 

--- a/TinyG2/settings/settings_Ultimaker.h
+++ b/TinyG2/settings/settings_Ultimaker.h
@@ -370,6 +370,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_Ultimaker_Rob_v9h.h
+++ b/TinyG2/settings/settings_Ultimaker_Rob_v9h.h
@@ -389,6 +389,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_default.h
+++ b/TinyG2/settings/settings_default.h
@@ -381,6 +381,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_othermill.h
+++ b/TinyG2/settings/settings_othermill.h
@@ -414,6 +414,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_othermill_test.h
+++ b/TinyG2/settings/settings_othermill_test.h
@@ -412,6 +412,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_probotixV90.h
+++ b/TinyG2/settings/settings_probotixV90.h
@@ -366,6 +366,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_shapeoko2.h
+++ b/TinyG2/settings/settings_shapeoko2.h
@@ -364,6 +364,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_shapeoko375_Dual.h
+++ b/TinyG2/settings/settings_shapeoko375_Dual.h
@@ -365,6 +365,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_shopbot_sbv300.h
+++ b/TinyG2/settings/settings_shopbot_sbv300.h
@@ -367,6 +367,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_shopbot_test.h
+++ b/TinyG2/settings/settings_shopbot_test.h
@@ -383,6 +383,50 @@
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
 
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0
+
 /*** User-Defined Data Defaults ***/
 
 #define USER_DATA_A0 0

--- a/TinyG2/settings/settings_test.h
+++ b/TinyG2/settings/settings_test.h
@@ -489,3 +489,48 @@
 #define G59_A_OFFSET 0
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
+
+
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0

--- a/TinyG2/settings/settings_zen7x12.h
+++ b/TinyG2/settings/settings_zen7x12.h
@@ -252,3 +252,48 @@
 #define G59_A_OFFSET 0
 #define G59_B_OFFSET 0
 #define G59_C_OFFSET 0
+
+
+// *** DEFAULT TOOL TABLE OFFSETS ***
+
+#define TT1_X_OFFSET 0
+#define TT1_Y_OFFSET 0
+#define TT1_Z_OFFSET 0
+#define TT1_A_OFFSET 0
+#define TT1_B_OFFSET 0
+#define TT1_C_OFFSET 0
+
+#define TT2_X_OFFSET 0
+#define TT2_Y_OFFSET 0
+#define TT2_Z_OFFSET 0
+#define TT2_A_OFFSET 0
+#define TT2_B_OFFSET 0
+#define TT2_C_OFFSET 0
+
+#define TT3_X_OFFSET 0
+#define TT3_Y_OFFSET 0
+#define TT3_Z_OFFSET 0
+#define TT3_A_OFFSET 0
+#define TT3_B_OFFSET 0
+#define TT3_C_OFFSET 0
+
+#define TT4_X_OFFSET 0
+#define TT4_Y_OFFSET 0
+#define TT4_Z_OFFSET 0
+#define TT4_A_OFFSET 0
+#define TT4_B_OFFSET 0
+#define TT4_C_OFFSET 0
+
+#define TT5_X_OFFSET 0
+#define TT5_Y_OFFSET 0
+#define TT5_Z_OFFSET 0
+#define TT5_A_OFFSET 0
+#define TT5_B_OFFSET 0
+#define TT5_C_OFFSET 0
+
+#define TT6_X_OFFSET 0
+#define TT6_Y_OFFSET 0
+#define TT6_Z_OFFSET 0
+#define TT6_A_OFFSET 0
+#define TT6_B_OFFSET 0
+#define TT6_C_OFFSET 0

--- a/TinyG2/tinyg2.h
+++ b/TinyG2/tinyg2.h
@@ -78,6 +78,7 @@ typedef uint16_t magic_t;		        // magic number size
 #define HOMING_AXES 4           // number of axes that can be homed (assumes Zxyabc sequence)
 #define MOTORS      6           // number of motors on the board
 #define COORDS      6           // number of supported coordinate systems (1-6)
+#define TOOLS       6           // number of entries in tool table (1-6)
 #define PWMS        2           // number of supported PWM channels
 
 // Note: If you change COORDS you must adjust the entries in cfgArray table in config.c


### PR DESCRIPTION
It would be painful to not have tool length offsets for my application, so I attempted to add them. It appears to work correctly, but has not seen extensive use yet. If there are things that could be done better, please suggest improvements.
