### PR TITLE
Corrected compile error related to feedrate override

### DIFF
--- a/TinyG2/config_app.h
+++ b/TinyG2/config_app.h
@@ -21,6 +21,19 @@
 #ifndef CONFIG_APP_H_ONCE
 #define CONFIG_APP_H_ONCE
 
+/* 
+ * The following is to fix an issue where feedrate override was being defined in some users
+ * settings files but not others. This would otherwise cause an undefined compile error.
+ *
+ */
+
+#ifndef MANUAL_FEEDRATE_OVERRIDE_ENABLE
+#define MANUAL_FEEDRATE_OVERRIDE_ENABLE false
+#endif
+#ifndef MANUAL_FEEDRATE_OVERRIDE_PARAMETER
+#define MANUAL_FEEDRATE_OVERRIDE_PARAMETER 1.00
+#endif
+
 /***********************************************************************************
  **** APPLICATION_SPECIFIC DEFINITIONS AND SETTINGS ********************************
  ***********************************************************************************/

--- a/TinyG2/settings/settings_probotixV90.h
+++ b/TinyG2/settings/settings_probotixV90.h
@@ -99,7 +99,7 @@
 #define M1_STEP_ANGLE 		    	1.8						// 1sa
 #define M1_TRAVEL_PER_REV	    	5.08					// 1tr
 #define M1_MICROSTEPS		    	8						// 1mi		1,2,4,8
-#define M1_POLARITY			    	0						// 1po		0=normal, 1=reversed
+#define M1_POLARITY			    	1						// 1po		0=normal, 1=reversed
 #define M1_POWER_MODE		    	MOTOR_POWER_MODE		// 1pm		standard
 #define M1_POWER_LEVEL		    	0.75		            // 1pl
 
@@ -107,7 +107,7 @@
 #define M2_STEP_ANGLE		    	1.8
 #define M2_TRAVEL_PER_REV	    	5.08
 #define M2_MICROSTEPS		    	8
-#define M2_POLARITY			    	1
+#define M2_POLARITY			    	0
 #define M2_POWER_MODE		    	MOTOR_POWER_MODE
 #define M2_POWER_LEVEL		    	0.75
 
@@ -115,7 +115,7 @@
 #define M3_STEP_ANGLE		    	1.8
 #define M3_TRAVEL_PER_REV	    	2.1166666
 #define M3_MICROSTEPS		    	8
-#define M3_POLARITY			    	0
+#define M3_POLARITY			    	1
 #define M3_POWER_MODE		    	MOTOR_POWER_MODE
 #define M3_POWER_LEVEL		    	0.50
 
@@ -150,7 +150,7 @@
 #define JUNCTION_DEVIATION_ABC      0.1                     // larger is faster
 
 #define X_AXIS_MODE			    	AXIS_STANDARD           // xam  see canonical_machine.h cmAxisMode for valid values
-#define X_VELOCITY_MAX		    	2400                    // xvm  G0 max velocity in mm/min
+#define X_VELOCITY_MAX		    	1600                    // xvm  G0 max velocity in mm/min
 #define X_FEEDRATE_MAX		    	X_VELOCITY_MAX          // xfr  G1 max feed rate in mm/min
 #define X_TRAVEL_MIN		    	0                       // xtn  minimum travel - used by soft limits and homing
 #define X_TRAVEL_MAX 		    	400                     // xtm  maximum travel - used by soft limits and homing
@@ -165,7 +165,7 @@
 #define X_ZERO_BACKOFF		    	2                       // xzb  mm
 
 #define Y_AXIS_MODE			    	AXIS_STANDARD
-#define Y_VELOCITY_MAX		    	2400
+#define Y_VELOCITY_MAX		    	1600
 #define Y_FEEDRATE_MAX		        Y_VELOCITY_MAX
 #define Y_TRAVEL_MIN			    0
 #define Y_TRAVEL_MAX		    	175


### PR DESCRIPTION
This fixes an issue where feedrate override enable and parameters was being defined in some users
 settings files but not others. This would otherwise cause an undefined compile error. 
A couple ifndef checks were added.