### PR TITLE
Delay driving spindle_enable_pin until we get its polarity setting

### DIFF
--- a/TinyG2/hardware.h
+++ b/TinyG2/hardware.h
@@ -154,7 +154,9 @@ static OutputPin<kGRBL_FeedHoldPinNumber> grbl_feedhold_pin;
 static OutputPin<kGRBL_CycleStartPinNumber> grbl_cycle_start_pin;
 
 static OutputPin<kGRBL_CommonEnablePinNumber> motor_common_enable_pin;
-static OutputPin<kSpindle_EnablePinNumber> spindle_enable_pin;
+
+//Delay driving spindle output enable until we get the polarity setting
+static OutputPin<kSpindle_EnablePinNumber> spindle_enable_pin(kNoInit);
 static OutputPin<kSpindle_DirPinNumber> spindle_dir_pin;
 static PWMOutputPin<kSpindle_PwmPinNumber> spindle_pwm_pin;
 static PWMOutputPin<kSpindle_Pwm2PinNumber> secondary_pwm_pin;

--- a/TinyG2/main.cpp
+++ b/TinyG2/main.cpp
@@ -159,6 +159,8 @@ void application_init_startup(void)
     canonical_machine_reset();
     spindle_init();                 // should be after PWM and canonical machine inits and config_init()
     spindle_reset();
+    // We delayed driving spindle enable until we know the enable polarity
+    spindle_enable_pin.init();
     // MOVED: report the system is ready is now in xio
 }
 

--- a/TinyG2/motate/utility/SamPins.h
+++ b/TinyG2/motate/utility/SamPins.h
@@ -70,6 +70,9 @@ namespace Motate {
 
         // For use on PWM pins only!
         kPWMPinInverted    = 1<<7,
+
+        // Delay calling init()
+        kNoInit = 0xffff,
     };
 
     enum PinInterruptOptions {
@@ -201,7 +204,7 @@ namespace Motate {
     template<int8_t pinNum>
     struct OutputPin : Pin<pinNum> {
         OutputPin() : Pin<pinNum>(kOutput) {};
-        OutputPin(const PinOptions options) : Pin<pinNum>(kOutput, options) {};
+        OutputPin(const PinOptions options) { if(options!=kNoInit) Pin<pinNum>::init(kOutput, options, true);};
         void init(const PinOptions options = kNormal) {Pin<pinNum>::init(kOutput, options);};
         uint32_t get() {
             return Pin<pinNum>::getOutputValue();


### PR DESCRIPTION
I happen to have an active low triggered relay for controlling the spindle. I found out that every time the board resets, the spindle gets turned on for about one second or so. Digging into the code, I was surprised to find out that all of the G2 pins are initialized in static object constructor! Will there be any safety concern, for example, the spindle enable pin here? I think at least we shall delay driving all output pins with configurable polarity until we get the settings. 

Right now, Due doesn't have any persistent storage. So for things like spindle enable, I have to change the default settings and compile a customized image. But then, motate currently have no way to initialize output pin value before actually driving the output. I could have patched motate to add that functionality. But I think it is better to delay driving the output pin until we called config_init(), in case we add the persistent storage in the future.
