### PR TITLE
Hard limits handling mod

### DIFF
--- a/TinyG2/TinyG2.xcodeproj/project.pbxproj
+++ b/TinyG2/TinyG2.xcodeproj/project.pbxproj
@@ -3207,6 +3207,8 @@
 		D49EC3F817054FDF00F2BF9B /* SAM4S8B.svd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = SAM4S8B.svd; sourceTree = "<group>"; };
 		D49EC3F917054FDF00F2BF9B /* SAM4S8C.svd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = SAM4S8C.svd; sourceTree = "<group>"; };
 		D49EC43517054FDF00F2BF9B /* atmel_sam.mk */ = {isa = PBXFileReference; explicitFileType = sourcecode.make; fileEncoding = 4; path = atmel_sam.mk; sourceTree = "<group>"; };
+		D4AC39221C9745780098D685 /* error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
+		D4AC39231C97517F0098D685 /* settings_printrbot_simple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = settings_printrbot_simple.h; sourceTree = "<group>"; };
 		D4B57631170737730070CCAE /* atmel_sam_series.mk */ = {isa = PBXFileReference; explicitFileType = sourcecode.make; fileEncoding = 4; path = atmel_sam_series.mk; sourceTree = "<group>"; };
 		D4B57632170737870070CCAE /* gcc_flash.ld */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = gcc_flash.ld; sourceTree = "<group>"; };
 		D4B57633170737870070CCAE /* gcc_sram.ld */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = gcc_sram.ld; sourceTree = "<group>"; };
@@ -3269,6 +3271,7 @@
 		D41D13F617374B7D00D522D9 /* settings */ = {
 			isa = PBXGroup;
 			children = (
+				D4AC39231C97517F0098D685 /* settings_printrbot_simple.h */,
 				D41D13F717374B7D00D522D9 /* settings_default.h */,
 				D4EC69F918CA2C1900DF8E4F /* settings_othermill.h */,
 				D41D13FD17374B7D00D522D9 /* settings_probotixV90.h */,
@@ -3312,6 +3315,7 @@
 				D4B6579F18B5C21500F8616C /* cycle_probing.cpp */,
 				D4B657A018B5C21500F8616C /* encoder.cpp */,
 				D4B657A118B5C21500F8616C /* encoder.h */,
+				D4AC39221C9745780098D685 /* error.h */,
 				D48F5A45172CB1F900D0E055 /* gcode_parser.cpp */,
 				D48F5A70172CB21100D0E055 /* gcode_parser.h */,
 				D4B93DEF1AAA9DFE00632FAB /* gpio.cpp */,

--- a/TinyG2/controller.cpp
+++ b/TinyG2/controller.cpp
@@ -307,11 +307,15 @@ static void _dispatch_kernel()
  * _controller_state() - manage controller connection, startup, and other state changes
  */
 
+Motate::Timeout _connection_timeout;
 static stat_t _controller_state()
 {
 	if (cs.controller_state == CONTROLLER_CONNECTED) {		// first time through after reset
+        cs.controller_state = CONTROLLER_STARTUP;
+        // This is here just to put a small delay in before the startup message.
+        _connection_timeout.set(10);
+    } else if ((cs.controller_state == CONTROLLER_STARTUP) && (_connection_timeout.isPast())) {		// first time through after reset
 		cs.controller_state = CONTROLLER_READY;
-        // Oops, we just skipped CONTROLLER_STARTUP. Do we still need it? -r
 		rpt_print_system_ready_message();
 	}
 	return (STAT_OK);

--- a/TinyG2/motate/MotateUSBCDC.h
+++ b/TinyG2/motate/MotateUSBCDC.h
@@ -429,8 +429,11 @@ namespace Motate {
                     _line_state = setup.valueLow();
 
                     // If the DTR changed, call connectionStateChanged (if it's defined)
-                    if (connection_state_changed_callback && ((_old_line_state & kCDCControlState_DTR) != (_line_state & kCDCControlState_DTR))) {
-                        connection_state_changed_callback(_line_state & kCDCControlState_DTR);
+                    if (((_old_line_state & kCDCControlState_DTR) != (_line_state & kCDCControlState_DTR))) {
+                        flush();
+                        if (connection_state_changed_callback) {
+                            connection_state_changed_callback(_line_state & kCDCControlState_DTR);
+                        }
                     }
 
                     // Auto-reset into the bootloader is triggered when the port, already open at 1200 bps, is closed.

--- a/TinyG2/motate/SamUSB.cpp
+++ b/TinyG2/motate/SamUSB.cpp
@@ -501,10 +501,10 @@ namespace Motate {
 	}
 
 	// Flush an endpoint after sending data.
-	void _flushEndpoint(uint8_t endpoint) {
-    _clearFIFOControl(endpoint);
-    _resetEndpointBuffer(endpoint);
-	}
+    void _flushEndpoint(uint8_t endpoint) {
+        _clearFIFOControl(endpoint);
+        _resetEndpointBuffer(endpoint);
+    }
 
 	// Send the data in a buffer to an endpoint.
 	// Does not automatically flush UNLESS it fills an endpoint buffer exactly.

--- a/TinyG2/motate/utility/SamTimers.h
+++ b/TinyG2/motate/utility/SamTimers.h
@@ -867,6 +867,32 @@ namespace Motate {
 		{} while ( SysTickTimer.getValue() < doneTime );
 	}
 
+    struct Timeout {
+        uint32_t start_, delay_;
+        Timeout() : start_ {0}, delay_ {0} {};
+
+        bool isSet() {
+            return (start_ > 0);
+        }
+
+        bool isPast() {
+            if (!isSet()) {
+                return false;
+            }
+            return ((SysTickTimer.getValue() - start_) > delay_);
+        };
+
+        void set(uint32_t delay) {
+            start_ = SysTickTimer.getValue();
+            delay_ = delay;
+        };
+
+        void clear() {
+            start_ = 0;
+            delay_ = 0;
+        }
+    };
+
 } // namespace Motate
 
 #define MOTATE_TIMER_INTERRUPT(number) template<> void Timer<number>::interrupt()

--- a/TinyG2/platform/atmel_sam.gdb
+++ b/TinyG2/platform/atmel_sam.gdb
@@ -22,6 +22,19 @@ set history expansion on
 
 set print pretty on
 
-# Halt the device
-monitor reset halt
+define boot_from_flash
+  monitor at91sam3 gpnvm set 1
+end
 
+define reset
+  boot_from_flash
+  monitor reset init
+end
+
+define flash
+  make
+  load
+  reset
+end
+
+reset

--- a/TinyG2/tinyg2.h
+++ b/TinyG2/tinyg2.h
@@ -39,7 +39,7 @@
 
 // You must tag the build first using "git tag ###.##" (you chose the build number for the tag, obviously)
 
-#define TINYG_FIRMWARE_BUILD            089.02 // labeled as a compile w/o a build number
+#define TINYG_FIRMWARE_BUILD            089.03 // fixes for "startup banner" (new connection)
 //#define TINYG_FIRMWARE_BUILD            GIT_EXACT_VERSION           // extract build number from tag
 //#define TINYG_FIRMWARE_BUILD_STRING     GIT_VERSION                 // extract extended build info from git
 

--- a/Tools/error.py
+++ b/Tools/error.py
@@ -2,13 +2,19 @@ import re
 import json
 
 codes = {}
-with open('../TinyG2/tinyg2.h') as fp:
+with open('../TinyG2/error.h') as fp:
     for line in fp.readlines():
-        match = re.match('\s*#define\s*(\w+)\s*([0-9]+)\s*(?://([\w\s\'0-9]*))?', line)
+        match = re.match(r'\s*#define\s*(\w+)\s*([0-9]+)\s*(?://([\w\s\'0-9]*))?', line)
         if match:
             name, value, description = match.groups()
             description = description.strip() if description else ''
             codes[value] = (name, description)
+        else:
+            match = re.match(r'\s*static const char stat_\([0-9]+\)\[\] PROGMEM = \"(\\"|[^"])+\"', line)
+            if match:
+                value, description = match.groups()
+                description = description.strip() if description else ''
+                codes[value][1] = description
 
 with open('g2_errors.json', 'w') as fp:
     json.dump(codes, fp, indent=3)


### PR DESCRIPTION
#137  While digging around G2 and testing the hard limits i've found the G2 ignores the limits state while starting up also it resets the machine just by issuing a clear command even if there is a tripped limit so i played a little and came up with this little code :

I created this function in "gpio.cpp" to scan hard limit inputs value when called:

bool scan_lims(void)				
{
    bool pin_val_rec=0;
    for (uint8_t ixz=0; ixz < DI_CHANNELS; ixz++) {
    	if (io.in[ixz].mode == INPUT_MODE_DISABLED || io.in[ixz].function != INPUT_FUNCTION_LIMIT) {
            continue;
	}   
    	pin_val_rec = pin_val_rec | _read_input_pin(ixz+1);
    }
    return(pin_val_rec);

}


Then i called it back in canonical_machine.cpp in canonical_machine_reset() to make sure not to ignore the recent limits condition during starts.

	if (scan_lims() == 1){
		cm.limit_requested = 1;
	}
	else{
		cm.limit_requested = 0;                 // resets switch closures that occurred during initialization
	}

and called it back again in cm_clear() to make sure not to ignore the recent limit state when issuing a clear command

void cm_clear()
{ 
	scan_lims();
	if (scan_lims() == 0){
		if (cm.machine_state == MACHINE_ALARM ) {
			cm.machine_state = MACHINE_PROGRAM_STOP;
		} else if (cm.machine_state == MACHINE_SHUTDOWN) {
			cm.machine_state = MACHINE_READY;
		}
	}
}

It could be tuned more but this is what i can do for now as i have zero programming skills.