### PR TITLE
Work on issue #225 - queue flush and clear handling

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -823,6 +823,7 @@ void cm_clear()
 {
     if (cm.machine_state == MACHINE_ALARM) {
         cm.machine_state = MACHINE_PROGRAM_STOP;
+        xio_flush_to_command();
     } else if (cm.machine_state == MACHINE_SHUTDOWN) {
         cm.machine_state = MACHINE_READY;
     }

--- a/g2core/controller.cpp
+++ b/g2core/controller.cpp
@@ -236,7 +236,7 @@ static void _dispatch_kernel(const devflags_t flags)
 
     // trap single character commands
     if      (*cs.bufp == '!') { cm_request_feedhold(); }
-    else if (*cs.bufp == '%') { cm_request_queue_flush(); }
+    else if (*cs.bufp == '%') { cm_request_queue_flush(); xio_flush_to_command(); }
     else if (*cs.bufp == '~') { cm_request_end_hold(); }
     else if (*cs.bufp == EOT) { cm_alarm(STAT_KILL_JOB, "EOT Received"); }
     else if (*cs.bufp == ENQ) { controller_request_enquiry(); }

--- a/g2core/plan_zoid.cpp
+++ b/g2core/plan_zoid.cpp
@@ -34,21 +34,21 @@
 
 //+++++ DIAGNOSTICS
 
-#if IN_DEBUGGER < 1
+//#if IN_DEBUGGER < 1
 #define LOG_RETURN(msg)  // LOG_RETURN with no action (production)
-#else
-#include "xio.h"
-static char logbuf[128];
-static void _logger(const char *msg, const mpBuf_t *bf)         // LOG_RETURN with full state dump
-{
-    sprintf(logbuf, "[%2d] %s (%d) mt:%5.2f, L:%1.3f [%1.3f, %1.3f, %1.3f] V:[%1.2f, %1.2f, %1.2f]\n",
-                    bf->buffer_number, msg, bf->hint, (bf->block_time * 60000),
-                    bf->length, bf->head_length, bf->body_length, bf->tail_length,
-                    bf->pv->exit_velocity, bf->cruise_velocity, bf->exit_velocity);
-    xio_writeline(logbuf);
-}
-#define LOG_RETURN(msg) { _logger(msg, bf); }
-#endif
+//#else
+//#include "xio.h"
+//static char logbuf[128];
+//static void _logger(const char *msg, const mpBuf_t *bf)         // LOG_RETURN with full state dump
+//{
+//    sprintf(logbuf, "[%2d] %s (%d) mt:%5.2f, L:%1.3f [%1.3f, %1.3f, %1.3f] V:[%1.2f, %1.2f, %1.2f]\n",
+//                    bf->buffer_number, msg, bf->hint, (bf->block_time * 60000),
+//                    bf->length, bf->head_length, bf->body_length, bf->tail_length,
+//                    bf->pv->exit_velocity, bf->cruise_velocity, bf->exit_velocity);
+//    xio_writeline(logbuf);
+//}
+//#define LOG_RETURN(msg) { _logger(msg, bf); }
+//#endif
 
 #if IN_DEBUGGER < 1
 #define TRAP_ZERO(t,m)

--- a/g2core/settings/settings_shopbot_sbv300.h
+++ b/g2core/settings/settings_shopbot_sbv300.h
@@ -56,7 +56,7 @@
 
 // Communications and reporting settings
 
-#define USB_SERIAL_PORTS_EXPOSED   2        // Valid options are 1 or 2, only!
+#define USB_SERIAL_PORTS_EXPOSED   1        // Valid options are 1 or 2, only!
 
 #define COMM_MODE JSON_MODE                      // one of: TEXT_MODE, JSON_MODE
 #define XIO_ENABLE_FLOW_CONTROL FLOW_CONTROL_RTS // FLOW_CONTROL_OFF, FLOW_CONTROL_RTS

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -76,7 +76,7 @@ extern OutputPin<kDebug3_PinNumber> debug_pin3;
 //extern OutputPin<kDebug4_PinNumber> debug_pin4;
 
 dda_timer_type dda_timer     {kTimerUpToMatch, FREQUENCY_DDA};      // stepper pulse generation
-load_timer_type load_timer;         // triggers load of next stepper segment
+//load_timer_type load_timer;         // triggers load of next stepper segment
 exec_timer_type exec_timer;         // triggers calculation of next+1 stepper segment
 fwd_plan_timer_type fwd_plan_timer; // triggers planning of next block
 
@@ -126,7 +126,7 @@ void stepper_init()
     dda_timer.setInterrupts(kInterruptOnOverflow | kInterruptPriorityHighest);
 
     // setup software interrupt load timer
-    load_timer.setInterrupts(kInterruptOnSoftwareTrigger | kInterruptPriorityHigh);
+//    load_timer.setInterrupts(kInterruptOnSoftwareTrigger | kInterruptPriorityHigh);
 
     // setup software interrupt exec timer & initial condition
     exec_timer.setInterrupts(kInterruptOnSoftwareTrigger | kInterruptPriorityMedium);
@@ -417,20 +417,21 @@ void st_request_load_move()
     stepper_debug("l");
     if (st_pre.buffer_state == PREP_BUFFER_OWNED_BY_LOADER) {       // bother interrupting
         stepper_debug("_");
-        load_timer.setInterruptPending();
+//        load_timer.setInterruptPending();
+        _load_move();
     }
 }
 
-namespace Motate {    // Define timer inside Motate namespace
-    template<>
-    void load_timer_type::interrupt()
-    {
-        load_timer.getInterruptCause();                             // read SR to clear interrupt condition
-        stepper_debug("L>");
-        _load_move();
-        stepper_debug("L+\n");
-    }
-} // namespace Motate
+//namespace Motate {    // Define timer inside Motate namespace
+//    template<>
+//    void load_timer_type::interrupt()
+//    {
+//        load_timer.getInterruptCause();                             // read SR to clear interrupt condition
+//        stepper_debug("L>");
+//        _load_move();
+//        stepper_debug("L+\n");
+//    }
+//} // namespace Motate
 
 /****************************************************************************************
  * _load_move() - Dequeue move and load into stepper runtime structure

--- a/g2core/xio.cpp
+++ b/g2core/xio.cpp
@@ -324,9 +324,11 @@ struct xio_t {
     void flushToCommand()
     {
         for (int8_t i = 0; i < _dev_count; ++i) {
-            if (DeviceWrappers[i]->flushToCommand()) {
-                return; // we only care to flush the one that last returned a control.
-            }
+            DeviceWrappers[i]->flushToCommand();
+            //if (DeviceWrappers[i]->flushToCommand()) {
+            //    return; // we only care to flush the one that last returned a control.
+            //}
+
         }
     }
 

--- a/g2core/xio.cpp
+++ b/g2core/xio.cpp
@@ -170,6 +170,7 @@ struct xioDeviceWrapperBase {                // C++ base class for device primit
     virtual int16_t readchar() { return -1; };
     virtual void flush() {};
     virtual void flushRead() {};       // This should call _flushLine() before flushing the device.
+    virtual bool flushToCommand() { return false; };
     virtual int16_t write(const char *buffer, int16_t len) { return -1; };
 
     virtual char *readline(devflags_t limit_flags, uint16_t &size) { return nullptr; };
@@ -315,6 +316,21 @@ struct xio_t {
     }
 
     /*
+     * flushToCommand() - flush all readable devices' read buffers up to the last returned command
+     *
+     * Note that only one device will flush.
+     *
+     */
+    void flushToCommand()
+    {
+        for (int8_t i = 0; i < _dev_count; ++i) {
+            if (DeviceWrappers[i]->flushToCommand()) {
+                return; // we only care to flush the one that last returned a control.
+            }
+        }
+    }
+
+    /*
      * readline() - read a complete line from a device
      *
      *    Reads a line of text from the next active device that has one ready. With some exceptions.
@@ -429,6 +445,8 @@ struct LineRXBuffer : RXBuffer<_size, owner_type, char> {
     uint16_t _lines_found;          // count of complete non-control lines that were found during scanning.
 
     volatile uint16_t _last_scan_offset;  // DEBUGGING
+
+    bool _last_returned_a_control = false;
 
     LineRXBuffer(owner_type owner) : parent_type{owner} {};
 
@@ -678,6 +696,8 @@ struct LineRXBuffer : RXBuffer<_size, owner_type, char> {
 
         _restartTransfer();
 
+        _last_returned_a_control = found_control;
+
         char *dst_ptr = _line_buffer;
         line_size = 0;
 
@@ -729,33 +749,34 @@ struct LineRXBuffer : RXBuffer<_size, owner_type, char> {
 
             if (ctrl_is_at_beginning_of_data) {
                 _read_offset = _scan_offset;
-            } else {
-                // special case: if the return value is '%'
-                // then we actually consider everything before it to be read
-
-                if ('%' == _line_buffer[0]) {
-                    // Things that must be managed here:
-                    // * _read_offset -- we're skipping data
-                    // * _lines_found -- we shouldn't have any lines "left"
-                    // * _skip_sections -- there's nothing to skip, we just did
-
-                    // Things that won't be changed (further):
-                    // * _scan_offset -- we're not changing past where it's scanned
-                    // * _line_start_offset -- we've already adjusted it
-                    // * _at_start_of_line -- should always be true when we're here
-
-                    // move the read buffer up to where we're scanning
-                    _read_offset = _scan_offset;
-
-                    // record that we have 0 lines (of data) in the buffer
-                    _lines_found = 0;
-
-                    // and clear out any skip sections we have
-                    while (!_skip_sections.is_empty()) {
-                        _skip_sections.pop_skip();
-                    }
-                }
             }
+//            else {
+//                // special case: if the return value is '%'
+//                // then we actually consider everything before it to be read
+//
+//                if ('%' == _line_buffer[0]) {
+//                    // Things that must be managed here:
+//                    // * _read_offset -- we're skipping data
+//                    // * _lines_found -- we shouldn't have any lines "left"
+//                    // * _skip_sections -- there's nothing to skip, we just did
+//
+//                    // Things that won't be changed (further):
+//                    // * _scan_offset -- we're not changing past where it's scanned
+//                    // * _line_start_offset -- we've already adjusted it
+//                    // * _at_start_of_line -- should always be true when we're here
+//
+//                    // move the read buffer up to where we're scanning
+//                    _read_offset = _scan_offset;
+//
+//                    // record that we have 0 lines (of data) in the buffer
+//                    _lines_found = 0;
+//
+//                    // and clear out any skip sections we have
+//                    while (!_skip_sections.is_empty()) {
+//                        _skip_sections.pop_skip();
+//                    }
+//                }
+//            }
 
 //            if (ctrl_is_at_beginning_of_data) {
 //                // attempt to request more data
@@ -831,6 +852,7 @@ struct LineRXBuffer : RXBuffer<_size, owner_type, char> {
         return _line_buffer;
     }; // readline
 
+
     // this is called from flushRead()
     void flush() {
         parent_type::flush();
@@ -847,6 +869,41 @@ struct LineRXBuffer : RXBuffer<_size, owner_type, char> {
         while (!_skip_sections.is_empty()) {
             _skip_sections.pop_skip();
         }
+    }; // flush
+
+    bool flushToCommand() {
+        if (!_last_returned_a_control) {
+            return false;
+        }
+
+        // Things that must be managed here:
+        // * _read_offset -- we're skipping data
+        // * _lines_found -- we shouldn't have any lines "left"
+        // * _skip_sections -- there's nothing to skip, we just did
+
+        // Things that won't be changed (further):
+        // * _scan_offset -- we're not changing past where it's scanned
+        // * _line_start_offset -- we've already adjusted it
+        // * _at_start_of_line -- should always be true when we're here
+
+        // Note that we DO NOT call parent::flush() here. That will toss data
+        // we haven't scanned yet, beyond where we got the command we want to
+        // flush to.
+
+        // move the read buffer up to where we ended scanning
+        _read_offset = _scan_offset;
+
+        // record that we have 0 lines (of data) in the buffer
+        _lines_found = 0;
+
+        // and clear out any skip sections we have
+        while (!_skip_sections.is_empty()) {
+            _skip_sections.pop_skip();
+        }
+
+        _last_returned_a_control = false;
+
+        return true;
     }; // flush
 
 }; // LineRXBuffer
@@ -888,11 +945,19 @@ struct xioDeviceWrapper : xioDeviceWrapperBase {    // describes a device for re
         return _dev->flush();
     }
 
-    virtual void flushRead() final {
+    void flushRead() final {
         // Flush out any partially or wholly read lines being stored:
         _rx_buffer.flush();
         _flushLine();
         return _dev->flushRead();
+    }
+
+    void _flushLine() {
+        // TODO: Call to flush the RX buffer line structures
+    };
+
+    bool flushToCommand() final {
+        return _rx_buffer.flushToCommand();
     }
 
     virtual int16_t write(const char *buffer, int16_t len) final {
@@ -909,10 +974,6 @@ struct xioDeviceWrapper : xioDeviceWrapperBase {    // describes a device for re
 
         size = 0;
         return NULL;
-    };
-
-    void _flushLine() {
-        // TODO: Call to flush the RX buffer line structures
     };
 
     void connectedStateChanged(bool connected) {
@@ -1127,10 +1188,23 @@ int16_t xio_writeline(const char *buffer, bool only_to_muted /*= false*/)
     return xio.writeline(buffer, only_to_muted);
 }
 
+/*
+ * write() - return true of the device is currently "connected" (there's a fair bit of interpretation)
+ */
+
 bool xio_connected()
 {
     return xio.connected();
 }
+
+/*
+ * xio_flush_to_command() - clear the last read channel up until the command that was read
+ */
+
+void xio_flush_to_command() {
+    return xio.flushToCommand();
+}
+
 
 
 /***********************************************************************************

--- a/g2core/xio.h
+++ b/g2core/xio.h
@@ -119,6 +119,7 @@ size_t xio_write(const char *buffer, size_t size, bool only_to_muted = false);
 char *xio_readline(devflags_t &flags, uint16_t &size);
 int16_t xio_writeline(const char *buffer, bool only_to_muted = false);
 bool xio_connected();
+void xio_flush_to_command();
 
 stat_t xio_set_spi(nvObj_t *nv);
 

--- a/g2core/xio.h
+++ b/g2core/xio.h
@@ -49,7 +49,8 @@
 #define XIO_H_ONCE
 
 //#include "g2core.h"                // not required if used in g2core project
-#include "config.h"                 // required for nvObj typedef
+#include "config.h"             // required for nvObj typedef
+#include "canonical_machine.h"  // needed for cm_has_hold()
 
 /**** Defines, Macros, and  Assorted Parameters ****/
 
@@ -97,6 +98,7 @@ enum xioDeviceEnum {                        // reconfigure this enum as you add 
     DEV_USB1,                               // must be 1
     DEV_UART1,                              // must be 2
 //  DEV_SPI0,                               // We can't have it here until we actually define it
+    DEV_FLASH_FILE,                         // must be 0
     DEV_MAX
 };
 
@@ -106,7 +108,7 @@ enum xioSPIMode {
 };
 
 
-/**** readline stuff -- TODO *****/
+/**** readline stuff *****/
 
 #define RX_BUFFER_MIN_SIZE       256        // minimum requested buffer size (they are usually larger)
 
@@ -160,6 +162,71 @@ extern "C" {
 #define CHAR_CYCLE_START (char)'~'
 #define CHAR_QUEUE_FLUSH (char)'%'
 //#define CHAR_BOOTLOADER ESC
+
+
+/**** xio_flash_file - object to hold in-flash (compiled-in) "files" to run ****/
+
+struct xio_flash_file {
+    const char * const _data;
+    const int32_t _length;
+
+    int32_t _read_offset = 0;
+
+    xio_flash_file(const char * const data, int32_t length) : _data{data}, _length{length} {};
+
+    void reset() {
+        _read_offset = 0;
+    };
+
+    const char *readline(bool control_only, uint16_t &line_size) {
+        line_size = 0;
+        if (_read_offset == _length) { return nullptr; }
+
+        if (control_only) {
+            char c = _data[_read_offset];
+            if (!
+                ((c == '!')         ||
+                 (c == '~')         ||
+                 (c == ENQ)         ||        // request ENQ/ack
+                 (c == CHAR_RESET)  ||        // ^X - reset (aka cancel, terminate)
+                 (c == CHAR_ALARM)  ||        // ^D - request job kill (end of transmission)
+                 (c == '%' && cm_has_hold())  // flush (only in feedhold or part of control header)
+                ))
+            {
+                return nullptr;
+            }
+        }
+
+        const char *line_start = _data + _read_offset;
+
+        while (_read_offset < _length) {
+            char c = _data[_read_offset++];
+
+            if (c == '\n') {
+                break;
+            }
+
+            line_size++;
+        }
+
+        return line_start;
+    };
+
+    bool isDone() {
+        return _read_offset == _length;
+    }
+};
+
+/**** convenience function to construct a xio_flash_file ****/
+
+template <int32_t length>
+constexpr xio_flash_file make_xio_flash_file(const char (&data)[length]) {
+    return {data, length};
+}
+
+/**** function prototype for file-sending ****/
+
+bool xio_send_file(xio_flash_file &file);
 
 #ifdef __TEXT_MODE
 


### PR DESCRIPTION
This is to fix #225.

Basically, the solution is to properly clear up to the command that requires a queue flush. This means a `{"clr":null}` or a `%`. Previously, only `%` was handled correctly. That code was moved to a new function (eventually called from) `xio_flush_to_command()` and now a `{"clr":null}` from an alarm state will trigger that code as well as a `%`.