### PR TITLE
Added “no parameters” test to arc moves

### DIFF
--- a/g2core/g2core.cppproj
+++ b/g2core/g2core.cppproj
@@ -21,10 +21,8 @@
     <OverrideVtorValue>exception_table</OverrideVtorValue>
     <eraseonlaunchrule>1</eraseonlaunchrule>
     <AsfVersion>3.5.0</AsfVersion>
-    <avrtoolinterface>
-    </avrtoolinterface>
-    <avrtool>
-    </avrtool>
+    <avrtoolinterface>SWD</avrtoolinterface>
+    <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
     <com_atmel_avrdbg_tool_samice>
       <ToolType>com.atmel.avrdbg.tool.samice</ToolType>
       <ToolName>J-Link</ToolName>
@@ -70,7 +68,7 @@
     <com_atmel_avrdbg_tool_atmelice>
       <ToolOptions>
         <InterfaceProperties>
-          <SwdClock>10000000</SwdClock>
+          <SwdClock>2000000</SwdClock>
         </InterfaceProperties>
         <InterfaceName>SWD</InterfaceName>
       </ToolOptions>
@@ -103,8 +101,8 @@
     </PercepioTrace>
     <preserveEEPROM>true</preserveEEPROM>
     <avrtoolserialnumber>J41800036434</avrtoolserialnumber>
-    <avrdeviceexpectedsignature>0x284E0A60</avrdeviceexpectedsignature>
-    <avrtoolinterfaceclock>10000000</avrtoolinterfaceclock>
+    <avrdeviceexpectedsignature>0x285E0A60</avrdeviceexpectedsignature>
+    <avrtoolinterfaceclock>2000000</avrtoolinterfaceclock>
     <custom>
       <ToolOptions xmlns="">
         <InterfaceProperties>

--- a/g2core/plan_arc.cpp
+++ b/g2core/plan_arc.cpp
@@ -133,6 +133,15 @@ stat_t cm_arc_feed(const float target[], const bool target_f[],     // target en
     // Some things you might think are errors but are not:
     //  - offset specified for linear axis (i.e. not one of the plane axes). Ignored
     //  - rotary axes are present. Ignored
+    //  - no parameters are specified. This can happen when G2 or G3 motion mode persists but
+    //    a non-arc, non-motion command is entered afterwards, such as M3 or T. Trapped here:
+
+    // Trap if no parameters were specified while in CW or CCW arc motion mode. This is OK
+    if (!(target_f[AXIS_X] | target_f[AXIS_Y] | target_f[AXIS_Z] |
+          offset_f[AXIS_X] | offset_f[AXIS_Y] | offset_f[AXIS_Z] |
+          radius_f | P_word_f)) {
+        return(STAT_OK);
+    }
 
     // trap missing feed rate
     if (fp_ZERO(cm.gm.feed_rate)) {


### PR DESCRIPTION
Solves a problem where in some cases a move can fail if the system is still in arc motion mode