### PR TITLE
Dev 209b random pauses

### DIFF
--- a/g2core/Makefile
+++ b/g2core/Makefile
@@ -58,5 +58,8 @@ endif
 ifeq ($(DEBUG),2)
 	DEVICE_DEFINES += DEBUG=1 IN_DEBUGGER=1
 endif
+ifeq ($(DEBUG),3)
+	DEVICE_DEFINES += DEBUG=1 IN_DEBUGGER=1 DEBUG_SEMIHOSTING=1
+endif
 
 # *** EOF ***

--- a/g2core/board/ArduinoDue/hardware.h
+++ b/g2core/board/ArduinoDue/hardware.h
@@ -129,9 +129,8 @@ using Motate::OutputPin;
 
 // Timer definitions. See stepper.h and other headers for setup
 typedef TimerChannel<3,0> dda_timer_type;	// stepper pulse generation in stepper.cpp
-typedef TimerChannel<4,0> load_timer_type;	    // request load timer in stepper.cpp
-typedef ServiceCall<1> exec_timer_type;	    // request exec timer in stepper.cpp
-typedef ServiceCall<2> fwd_plan_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<4,0> exec_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<5,0> fwd_plan_timer_type;	// request exec timer in stepper.cpp
 
 // Pin assignments
 

--- a/g2core/board/G2v9/hardware.h
+++ b/g2core/board/G2v9/hardware.h
@@ -129,9 +129,8 @@ using Motate::OutputPin;
 
 // Timer definitions. See stepper.h and other headers for setup
 typedef TimerChannel<3,0> dda_timer_type;	// stepper pulse generation in stepper.cpp
-typedef TimerChannel<4,0> load_timer_type;	    // request load timer in stepper.cpp
-typedef ServiceCall<1> exec_timer_type;	    // request exec timer in stepper.cpp
-typedef ServiceCall<2> fwd_plan_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<4,0> exec_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<5,0> fwd_plan_timer_type;	// request exec timer in stepper.cpp
 
 // Pin assignments
 

--- a/g2core/board/printrboardg2/hardware.h
+++ b/g2core/board/printrboardg2/hardware.h
@@ -127,9 +127,8 @@ using Motate::OutputPin;
 
 // Timer definitions. See stepper.h and other headers for setup
 typedef TimerChannel<3,0> dda_timer_type;	// stepper pulse generation in stepper.cpp
-typedef TimerChannel<4,0> load_timer_type;	// request load timer in stepper.cpp
-typedef ServiceCall<1> exec_timer_type;	// request exec timer in stepper.cpp
-typedef ServiceCall<2> fwd_plan_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<4,0> exec_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<5,0> fwd_plan_timer_type;	// request exec timer in stepper.cpp
 
 // Pin assignments
 

--- a/g2core/board/sbv300/hardware.h
+++ b/g2core/board/sbv300/hardware.h
@@ -126,9 +126,8 @@ using Motate::OutputPin;
 
 // Timer definitions. See stepper.h and other headers for setup
 typedef TimerChannel<3,0> dda_timer_type;	// stepper pulse generation in stepper.cpp
-typedef TimerChannel<4,0> load_timer_type;	// request load timer in stepper.cpp
-typedef ServiceCall<1> exec_timer_type;	// request exec timer in stepper.cpp
-typedef ServiceCall<2> fwd_plan_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<4,0> exec_timer_type;	// request exec timer in stepper.cpp
+typedef TimerChannel<5,0> fwd_plan_timer_type;	// request exec timer in stepper.cpp
 
 // Pin assignments
 

--- a/g2core/config.cpp
+++ b/g2core/config.cpp
@@ -178,8 +178,7 @@ stat_t config_test_assertions()
         (BAD_MAGIC(nvl.magic_start)) ||
         (BAD_MAGIC(nvl.magic_end)) ||
         (BAD_MAGIC(nvStr.magic_start)) ||
-        (BAD_MAGIC(nvStr.magic_end)) ||
-        (global_string_buf[GLOBAL_STRING_LEN-1] != NUL)) {
+        (BAD_MAGIC(nvStr.magic_end))) {
         return(cm_panic(STAT_CONFIG_ASSERTION_FAILURE, "config_test_assertions()"));
     }
     return (STAT_OK);

--- a/g2core/config.h
+++ b/g2core/config.h
@@ -177,7 +177,7 @@ typedef uint16_t index_t;               // use this if there are > 255 indexed o
 #define NV_MESSAGE_LEN 128              // sufficient space to contain end-user messages
 
                                         // pre-allocated defines (take RAM permanently)
-#define NV_SHARED_STRING_LEN 512        // shared string for string values
+#define NV_SHARED_STRING_LEN 1024        // shared string for string values
 #define NV_BODY_LEN 40                  // body elements - allow for 1 parent + N children
 #define NV_EXEC_LEN 10                  // elements reserved for exec, which won't directly respond
 // (each body element takes about 30 bytes of RAM)

--- a/g2core/config_app.cpp
+++ b/g2core/config_app.cpp
@@ -202,7 +202,7 @@ const cfgItem_t cfgArray[] = {
     { "1","1sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_1].step_angle,     M1_STEP_ANGLE },
     { "1","1tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_1].travel_rev,     M1_TRAVEL_PER_REV },
     { "1","1mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_1].microsteps,     M1_MICROSTEPS },
-    { "1","1su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_1].steps_per_unit,	M1_STEPS_PER_UNIT },
+    { "1","1su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_1].steps_per_unit, M1_STEPS_PER_UNIT },
     { "1","1po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_1].polarity,       M1_POLARITY },
     { "1","1pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M1_POWER_MODE },
     { "1","1pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_1].power_level,    M1_POWER_LEVEL },
@@ -213,7 +213,7 @@ const cfgItem_t cfgArray[] = {
     { "2","2sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_2].step_angle,     M2_STEP_ANGLE },
     { "2","2tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_2].travel_rev,     M2_TRAVEL_PER_REV },
     { "2","2mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_2].microsteps,     M2_MICROSTEPS },
-    { "2","2su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_2].steps_per_unit,	M2_STEPS_PER_UNIT },
+    { "2","2su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_2].steps_per_unit, M2_STEPS_PER_UNIT },
     { "2","2po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_2].polarity,       M2_POLARITY },
     { "2","2pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M2_POWER_MODE },
     { "2","2pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_2].power_level,    M2_POWER_LEVEL},
@@ -225,7 +225,7 @@ const cfgItem_t cfgArray[] = {
     { "3","3sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_3].step_angle,     M3_STEP_ANGLE },
     { "3","3tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_3].travel_rev,     M3_TRAVEL_PER_REV },
     { "3","3mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_3].microsteps,     M3_MICROSTEPS },
-    { "3","3su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_3].steps_per_unit,	M3_STEPS_PER_UNIT },
+    { "3","3su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_3].steps_per_unit, M3_STEPS_PER_UNIT },
     { "3","3po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_3].polarity,       M3_POLARITY },
     { "3","3pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M3_POWER_MODE },
     { "3","3pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_3].power_level,    M3_POWER_LEVEL },
@@ -237,7 +237,7 @@ const cfgItem_t cfgArray[] = {
     { "4","4sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_4].step_angle,     M4_STEP_ANGLE },
     { "4","4tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_4].travel_rev,     M4_TRAVEL_PER_REV },
     { "4","4mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_4].microsteps,     M4_MICROSTEPS },
-    { "4","4su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_4].steps_per_unit,	M4_STEPS_PER_UNIT },
+    { "4","4su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_4].steps_per_unit, M4_STEPS_PER_UNIT },
     { "4","4po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_4].polarity,       M4_POLARITY },
     { "4","4pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M4_POWER_MODE },
     { "4","4pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_4].power_level,    M4_POWER_LEVEL },
@@ -249,7 +249,7 @@ const cfgItem_t cfgArray[] = {
     { "5","5sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_5].step_angle,     M5_STEP_ANGLE },
     { "5","5tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_5].travel_rev,     M5_TRAVEL_PER_REV },
     { "5","5mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_5].microsteps,     M5_MICROSTEPS },
-    { "5","5su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_5].steps_per_unit,	M5_STEPS_PER_UNIT },
+    { "5","5su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_5].steps_per_unit, M5_STEPS_PER_UNIT },
     { "5","5po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_5].polarity,       M5_POLARITY },
     { "5","5pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M5_POWER_MODE },
     { "5","5pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_5].power_level,    M5_POWER_LEVEL },
@@ -261,7 +261,7 @@ const cfgItem_t cfgArray[] = {
     { "6","6sa",_fip, 3, st_print_sa, get_flt, st_set_sa,  (float *)&st_cfg.mot[MOTOR_6].step_angle,     M6_STEP_ANGLE },
     { "6","6tr",_fipc,4, st_print_tr, get_flt, st_set_tr,  (float *)&st_cfg.mot[MOTOR_6].travel_rev,     M6_TRAVEL_PER_REV },
     { "6","6mi",_fip, 0, st_print_mi, get_ui8, st_set_mi,  (float *)&st_cfg.mot[MOTOR_6].microsteps,     M6_MICROSTEPS },
-    { "6","6su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_6].steps_per_unit,	M6_STEPS_PER_UNIT },
+    { "6","6su",_fipi,5, st_print_su, st_get_su,st_set_su, (float *)&st_cfg.mot[MOTOR_6].steps_per_unit, M6_STEPS_PER_UNIT },
     { "6","6po",_fip, 0, st_print_po, get_ui8, set_01,     (float *)&st_cfg.mot[MOTOR_6].polarity,       M6_POLARITY },
     { "6","6pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, (float *)&cs.null,                            M6_POWER_MODE },
     { "6","6pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  (float *)&st_cfg.mot[MOTOR_6].power_level,    M6_POWER_LEVEL },
@@ -599,12 +599,12 @@ const cfgItem_t cfgArray[] = {
     { "g30","g30c",_fi,  3, cm_print_cpos, get_flt, set_ro, (float *)&cm.gmx.g30_position[AXIS_C], 0 },
 
     // Default values for current tool length offsets (not configurable, set to zero)
-    { "tl","tlx",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_X], 0 },
-    { "tl","tly",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Y], 0 },
-    { "tl","tlz",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Z], 0 },
-    { "tl","tla",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_A], 0 },
-    { "tl","tlb",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_B], 0 },
-    { "tl","tlc",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_C], 0 },
+    { "tof","tofx",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_X], 0 },
+    { "tof","tofy",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Y], 0 },
+    { "tof","tofz",_fipc, 3, cm_print_cofs, get_flt, set_flu,(float *)&cm.tl_offset[AXIS_Z], 0 },
+    { "tof","tofa",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_A], 0 },
+    { "tof","tofb",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_B], 0 },
+    { "tof","tofc",_fip,  3, cm_print_cofs, get_flt, set_flt,(float *)&cm.tl_offset[AXIS_C], 0 },
 /*
     { "tl","tlx",_fipc, 3, cm_print_cofs, cm_get_tof, set_flu,(float *)&cm.tl_offset[AXIS_X], 0 },
     { "tl","tly",_fipc, 3, cm_print_cofs, cm_get_tof, set_flu,(float *)&cm.tl_offset[AXIS_Y], 0 },
@@ -1122,7 +1122,7 @@ const cfgItem_t cfgArray[] = {
     { "","g28",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },    // g28 home position
     { "","g30",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },    // g30 home position
     // +9 = 45
-    { "","tl",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },     // tl offsets
+    { "","tof",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },     // tof offsets
     { "","tt1",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },    // tt offsets
     { "","tt2",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },    // tt offsets
     { "","tt3",_f0, 0, tx_print_nul, get_grp, set_grp,(float *)&cs.null,0 },    // tt offsets

--- a/g2core/controller.h
+++ b/g2core/controller.h
@@ -28,9 +28,10 @@
 #ifndef CONTROLLER_H_ONCE
 #define CONTROLLER_H_ONCE
 
+#include "xio.h"
+
 // see also: g2core.h MESSAGE_LEN and config.h NV_ lengths
-#define SAVED_BUFFER_LEN 80             // saved buffer size (for reporting only)
-#define MAXED_BUFFER_LEN 255            // same as streaming RX buffer size as a worst case
+#define SAVED_BUFFER_LEN RX_BUFFER_SIZE // saved buffer size (for reporting only)
 #define OUTPUT_BUFFER_LEN 512           // text buffer size
 
 #define LED_NORMAL_BLINK_RATE 3000      // blink rate for normal operation (in ms)

--- a/g2core/error.h
+++ b/g2core/error.h
@@ -53,9 +53,6 @@
 typedef uint8_t stat_t;
 extern stat_t status_code;
 
-#define GLOBAL_STRING_LEN 256  // allow sufficient space for JSON responses and message strings
-extern char global_string_buf[];
-
 char *get_status_message(stat_t status);
 
 // ritorno is a handy way to provide exception returns

--- a/g2core/gcode_parser.cpp
+++ b/g2core/gcode_parser.cpp
@@ -2,8 +2,8 @@
  * gcode_parser.cpp - rs274/ngc Gcode parser
  * This file is part of the g2core project
  *
- * Copyright (c) 2010 - 2016 Alden S. Hart, Jr.
- * Copyright (c) 2016 Rob Giseburt
+ * Copyright (c) 2010 - 2017 Alden S. Hart, Jr.
+ * Copyright (c) 2016 - 2017 Rob Giseburt
  *
  * This file ("the software") is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2 as published by the
@@ -107,7 +107,7 @@ stat_t gcode_parser(char *block)
  *   - block_delete_flag is set true if block delete encountered, false otherwise
  */
 
-static char _normalize_scratch[RX_BUFFER_MIN_SIZE];
+char _normalize_scratch[RX_BUFFER_SIZE];
 
 static void _normalize_gcode_block(char *str, char **active_comment, uint8_t *block_delete_flag)
 {
@@ -359,7 +359,7 @@ static stat_t _get_next_gcode_word(char **pstr, char *letter, float *value)
     char *end;
     *value = strtof(*pstr, &end);
     if(end == *pstr) {
-        return(STAT_BAD_NUMBER_FORMAT);
+            return(STAT_BAD_NUMBER_FORMAT);
     }    // more robust test then checking for value=0;
     *pstr = end;
     return (STAT_OK);            // pointer points to next character after the word
@@ -409,9 +409,9 @@ static stat_t _validate_gcode_block(char *active_comment)
 
 static stat_t _parse_gcode_block(char *buf, char *active_comment)
 {
-    char *pstr = (char *)buf;       // persistent pointer into gcode block for parsing words
-    char letter;                    // parsed letter, eg.g. G or X or Y
-    float value = 0;                // value parsed from letter (e.g. 2 for G2)
+    char *pstr = (char *)buf;                   // persistent pointer into gcode block for parsing words
+    char letter;                                // parsed letter, eg.g. G or X or Y
+    float value = 0;                            // value parsed from letter (e.g. 2 for G2)
     stat_t status = STAT_OK;
 
     // set initial state for new move
@@ -574,7 +574,7 @@ static stat_t _parse_gcode_block(char *buf, char *active_comment)
             case 'K': SET_NON_MODAL (arc_offset[2], value);
             case 'L': SET_NON_MODAL (L_word, value);
             case 'R': SET_NON_MODAL (arc_radius, value);
-            case 'N': SET_NON_MODAL (linenum,(uint32_t)value);        // line number
+            case 'N': SET_NON_MODAL (linenum,(uint32_t)value);      // line number
             default: status = STAT_GCODE_COMMAND_UNSUPPORTED;
         }
         if(status != STAT_OK) break;
@@ -660,15 +660,15 @@ static stat_t _execute_gcode_block(char *active_comment)
     switch (cm.gn.next_action) {                            // Tool length offsets
         case NEXT_ACTION_SET_TL_OFFSET: {                   // G43
             ritorno(cm_set_tl_offset(cm.gn.H_word, false)); 
-            break; 
+            break;
         }
         case NEXT_ACTION_SET_ADDITIONAL_TL_OFFSET: {        // G43.2
             ritorno(cm_set_tl_offset(cm.gn.H_word, true)); 
-            break; 
+            break;
         }
         case NEXT_ACTION_CANCEL_TL_OFFSET: {                // G49
-            ritorno(cm_cancel_tl_offset()); 
-            break; 
+            ritorno(cm_cancel_tl_offset());
+            break;
         }
     }
 
@@ -681,9 +681,9 @@ static stat_t _execute_gcode_block(char *active_comment)
     //--> set retract mode goes here
 
     switch (cm.gn.next_action) {
-        case NEXT_ACTION_SET_G28_POSITION:  { status = cm_set_g28_position(); break;}                               // G28.1
+        case NEXT_ACTION_SET_G28_POSITION:  { status = cm_set_g28_position(); break;}                           // G28.1
         case NEXT_ACTION_GOTO_G28_POSITION: { status = cm_goto_g28_position(cm.gn.target, cm.gf.target); break;}    // G28
-        case NEXT_ACTION_SET_G30_POSITION:  { status = cm_set_g30_position(); break;}                               // G30.1
+        case NEXT_ACTION_SET_G30_POSITION:  { status = cm_set_g30_position(); break;}                           // G30.1
         case NEXT_ACTION_GOTO_G30_POSITION: { status = cm_goto_g30_position(cm.gn.target, cm.gf.target); break;}    // G30
 
         case NEXT_ACTION_SEARCH_HOME:         { status = cm_homing_cycle_start(); break;}                           // G28.2
@@ -697,12 +697,12 @@ static stat_t _execute_gcode_block(char *active_comment)
 
         case NEXT_ACTION_SET_G10_DATA:           { status = cm_set_g10_data(cm.gn.parameter, cm.gn.L_word, cm.gn.target, cm.gf.target); break;}
         case NEXT_ACTION_SET_ORIGIN_OFFSETS:     { status = cm_set_origin_offsets(cm.gn.target, cm.gf.target); break;}// G92
-        case NEXT_ACTION_RESET_ORIGIN_OFFSETS:   { status = cm_reset_origin_offsets(); break;}                      // G92.1
-        case NEXT_ACTION_SUSPEND_ORIGIN_OFFSETS: { status = cm_suspend_origin_offsets(); break;}                    // G92.2
-        case NEXT_ACTION_RESUME_ORIGIN_OFFSETS:  { status = cm_resume_origin_offsets(); break;}                     // G92.3
+        case NEXT_ACTION_RESET_ORIGIN_OFFSETS:   { status = cm_reset_origin_offsets(); break;}                  // G92.1
+        case NEXT_ACTION_SUSPEND_ORIGIN_OFFSETS: { status = cm_suspend_origin_offsets(); break;}                // G92.2
+        case NEXT_ACTION_RESUME_ORIGIN_OFFSETS:  { status = cm_resume_origin_offsets(); break;}                 // G92.3
 
         case NEXT_ACTION_JSON_COMMAND_SYNC:       { status = cm_json_command(active_comment); break;}               // M100
-        case NEXT_ACTION_JSON_WAIT:               { status = cm_json_wait(active_comment); break;}                  // M101
+        case NEXT_ACTION_JSON_WAIT:               { status = cm_json_wait(active_comment); break;}              // M101
 //      case NEXT_ACTION_JSON_COMMAND_IMMEDIATE:  { status = mp_json_command_immediate(active_comment); break;}     // M102
 
         case NEXT_ACTION_DEFAULT: {
@@ -711,7 +711,7 @@ static stat_t _execute_gcode_block(char *active_comment)
                 case MOTION_MODE_CANCEL_MOTION_MODE: { cm.gm.motion_mode = cm.gn.motion_mode; break;}               // G80
                 case MOTION_MODE_STRAIGHT_TRAVERSE:  { status = cm_straight_traverse(cm.gn.target, cm.gf.target); break;} // G0
                 case MOTION_MODE_STRAIGHT_FEED:      { status = cm_straight_feed(cm.gn.target, cm.gf.target); break;} // G1
-                case MOTION_MODE_CW_ARC:                                                                            // G2
+                case MOTION_MODE_CW_ARC:                                                                        // G2
                 case MOTION_MODE_CCW_ARC: { status = cm_arc_feed(cm.gn.target,     cm.gf.target,                    // G3
                                                                  cm.gn.arc_offset, cm.gf.arc_offset,
                                                                  cm.gn.arc_radius, cm.gf.arc_radius,

--- a/g2core/main.cpp
+++ b/g2core/main.cpp
@@ -49,7 +49,6 @@
 /******************** System Globals *************************/
 
 stat_t status_code;						    // allocate a variable for the ritorno macro
-char global_string_buf[GLOBAL_STRING_LEN];	// allocate a string for global message use
 
 /************* System Globals For Diagnostics ****************/
 

--- a/g2core/plan_exec.cpp
+++ b/g2core/plan_exec.cpp
@@ -274,7 +274,7 @@ stat_t mp_exec_move()
             if (bf->buffer_state == MP_BUFFER_PREPPED) {
                 if (cm.motion_state == MOTION_RUN) {
 #if IN_DEBUGGER == 1
-                    __asm__("BKPT"); // we are running but don't have a block planned
+//                    __asm__("BKPT"); // we are running but don't have a block planned
 #endif
                 }
                 // We need to have it planned. We don't want to do this here, as it

--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -72,7 +72,7 @@ mpMotionRuntimeSingleton_t mr;      // context for block runtime
 #define JSON_COMMAND_BUFFER_SIZE 3
 
 struct json_command_buffer_t {
-    char buf[RX_BUFFER_MIN_SIZE];
+    char buf[RX_BUFFER_SIZE];
     json_command_buffer_t *pv;
     json_command_buffer_t *nx;
 };

--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -59,9 +59,10 @@ stat_t rpt_exception(stat_t status, const char *msg)
 
         // you cannot send an exception report if the USB has not been set up. Causes a processor exception.
         if (cs.controller_state >= CONTROLLER_READY) {
-           sprintf(global_string_buf, "{\"er\":{\"fb\":%0.2f,\"st\":%d,\"msg\":\"%s - %s\"}}\n",
+            char buffer[128];
+            sprintf(buffer, "{\"er\":{\"fb\":%0.2f,\"st\":%d,\"msg\":\"%s - %s\"}}\n",
                                         G2CORE_FIRMWARE_BUILD, status, get_status_message(status), msg);
-           xio_writeline(global_string_buf);
+            xio_writeline(buffer);
         }
     }
     return (status);            // makes it possible to inline, e.g: return(rpt_exception(status));

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -76,7 +76,6 @@ extern OutputPin<kDebug3_PinNumber> debug_pin3;
 //extern OutputPin<kDebug4_PinNumber> debug_pin4;
 
 dda_timer_type dda_timer     {kTimerUpToMatch, FREQUENCY_DDA};      // stepper pulse generation
-//load_timer_type load_timer;         // triggers load of next stepper segment
 exec_timer_type exec_timer;         // triggers calculation of next+1 stepper segment
 fwd_plan_timer_type fwd_plan_timer; // triggers planning of next block
 
@@ -124,9 +123,6 @@ void stepper_init()
     // optimal for 200 KHz DDA clock before the time in the OFF cycle is too short.
     // If you need more pulse width you need to drop the DDA clock rate
     dda_timer.setInterrupts(kInterruptOnOverflow | kInterruptPriorityHighest);
-
-    // setup software interrupt load timer
-//    load_timer.setInterrupts(kInterruptOnSoftwareTrigger | kInterruptPriorityHigh);
 
     // setup software interrupt exec timer & initial condition
     exec_timer.setInterrupts(kInterruptOnSoftwareTrigger | kInterruptPriorityMedium);
@@ -417,21 +413,9 @@ void st_request_load_move()
     stepper_debug("l");
     if (st_pre.buffer_state == PREP_BUFFER_OWNED_BY_LOADER) {       // bother interrupting
         stepper_debug("_");
-//        load_timer.setInterruptPending();
         _load_move();
     }
 }
-
-//namespace Motate {    // Define timer inside Motate namespace
-//    template<>
-//    void load_timer_type::interrupt()
-//    {
-//        load_timer.getInterruptCause();                             // read SR to clear interrupt condition
-//        stepper_debug("L>");
-//        _load_move();
-//        stepper_debug("L+\n");
-//    }
-//} // namespace Motate
 
 /****************************************************************************************
  * _load_move() - Dequeue move and load into stepper runtime structure

--- a/g2core/xio.h
+++ b/g2core/xio.h
@@ -60,8 +60,6 @@
 #undef  _FDEV_EOF
 #define _FDEV_EOF -2
 
-#define USB_LINE_BUFFER_SIZE    255         // text buffer size
-
 //*** Device flags ***
 typedef uint16_t devflags_t;                // might need to bump to 32 be 16 or 32
 
@@ -110,7 +108,7 @@ enum xioSPIMode {
 
 /**** readline stuff *****/
 
-#define RX_BUFFER_MIN_SIZE       256        // minimum requested buffer size (they are usually larger)
+#define RX_BUFFER_SIZE       512            // maximum length of recieved lines from xio_readline
 
 /**** function prototypes ****/
 


### PR DESCRIPTION
Yet another attempt at #209. Note that this fix is mostly in synthetos/motate#6.

This is a two-pronged fix (note that these ONLY apply to Sam3x-based boards):

1) The USB stack was not handling all of the interrupt cases correctly. With the use of a (rather expensive) USB analyzer, we were able to identify a few cases that would have otherwise been very difficult to locate.
2) Remove all uses of the Motate SysCall utility in planning/forward-planning/exec/load train. This should remove any unnecessary latency in that system.