### PR TITLE
Inch mode precision fixes (#296)

### DIFF
--- a/g2core/canonical_machine.cpp
+++ b/g2core/canonical_machine.cpp
@@ -2439,8 +2439,14 @@ stat_t cm_get_feed(nvObj_t *nv)
 
 stat_t cm_get_pos(nvObj_t *nv)
 {
-    nv->value = cm_get_work_position(ACTIVE_MODEL, _get_axis(nv->index));
+    uint8_t axis = _get_axis(nv->index);
+    nv->value = cm_get_work_position(ACTIVE_MODEL, axis);
     nv->precision = GET_TABLE_WORD(precision);
+    if ((axis <= AXIS_Z) && (cm_get_units_mode(ACTIVE_MODEL) == INCHES)) {
+      // Display in inches needs more postdecimal digits to retain
+      // significance.  Three extra digits is generally enough.
+      nv->precision += 3;
+    }
     nv->valuetype = TYPE_FLOAT;
     return (STAT_OK);
 }
@@ -2890,6 +2896,7 @@ static const char fmt_cofs[] = "[%s%s] %s %s offset%20.3f%s\n";
 static const char fmt_cpos[] = "[%s%s] %s %s position%18.3f%s\n";
 
 static const char fmt_pos[] = "%c position:%15.3f%s\n";
+static const char fmt_pos_inches[] = "%c position:%15.6f%s\n";
 static const char fmt_mpo[] = "%c machine posn:%11.3f%s\n";
 static const char fmt_ofs[] = "%c work offset:%12.3f%s\n";
 static const char fmt_tof[] = "%c tool length offset:%12.3f%s\n";
@@ -2967,7 +2974,7 @@ void cm_print_zb(nvObj_t *nv) { _print_axis_flt(nv, fmt_Xzb);}
 void cm_print_cofs(nvObj_t *nv) { _print_axis_coord_flt(nv, fmt_cofs);}
 void cm_print_cpos(nvObj_t *nv) { _print_axis_coord_flt(nv, fmt_cpos);}
 
-void cm_print_pos(nvObj_t *nv) { _print_pos(nv, fmt_pos, cm_get_units_mode(MODEL));}
+void cm_print_pos(nvObj_t *nv) { _print_pos(nv, (cm_get_units_mode(MODEL) == INCHES) ? fmt_pos_inches : fmt_pos, cm_get_units_mode(MODEL));}
 void cm_print_mpo(nvObj_t *nv) { _print_pos(nv, fmt_mpo, MILLIMETERS);}
 void cm_print_ofs(nvObj_t *nv) { _print_pos(nv, fmt_ofs, MILLIMETERS);}
 void cm_print_tof(nvObj_t *nv) { _print_pos(nv, fmt_tof, MILLIMETERS);}

--- a/g2core/config.cpp
+++ b/g2core/config.cpp
@@ -677,6 +677,7 @@ nvObj_t *nv_add_float(const char *token, const float value)    // add a float ob
         }
         strncpy(nv->token, token, TOKEN_LEN);
         nv->value = value;
+        nv->precision = 7;           // Full precision of single float
         nv->valuetype = TYPE_FLOAT;
         return (nv);
     }

--- a/g2core/config_app.cpp
+++ b/g2core/config_app.cpp
@@ -1293,6 +1293,9 @@ void preprocess_float(nvObj_t *nv)
         if (cfgArray[nv->index].flags & F_CONVERT) {        // standard units conversion
             if ((type == AXIS_TYPE_LINEAR) || (type == AXIS_TYPE_SYSTEM)) {
                 nv->value *= INCHES_PER_MM;
+                // After conversion to inches, more postdecimal digits are needed
+                // to retain significance.  Three extra digits is generally enough.
+                nv->precision += 3;
             }
         } else if (cfgArray[nv->index].flags & F_ICONVERT) {// inverse units conversion
             if ((type == AXIS_TYPE_LINEAR) || (type == AXIS_TYPE_SYSTEM)) {
@@ -1300,8 +1303,6 @@ void preprocess_float(nvObj_t *nv)
             }
         }
     }
-    nv->precision = GET_TABLE_WORD(precision);
-    nv->valuetype = TYPE_FLOAT;
 }
 
 /*

--- a/g2core/json_parser.cpp
+++ b/g2core/json_parser.cpp
@@ -297,6 +297,7 @@ static stat_t _get_nv_pair(nvObj_t *nv, char **pstr, int8_t *depth)
             nv->valuetype = TYPE_NULL;                  // report back an error
             return (STAT_BAD_NUMBER_FORMAT);
         }
+        nv->precision = 7;                              // Full precision of single float
         nv->valuetype = TYPE_FLOAT;
 
     // object parent

--- a/g2core/text_parser.cpp
+++ b/g2core/text_parser.cpp
@@ -124,6 +124,7 @@ static stat_t _text_parser_kernal(char *str, nvObj_t *nv)
         nv->value = strtof(str, &rd);           // rd used as end pointer
         if (rd != str) {
             nv->valuetype = TYPE_FLOAT;
+            nv->precision = 7;                  // Full precision of single float
         }
     }
 


### PR DESCRIPTION
Fix for #296 

Reports in inches need 3 more decimal places than in mm.
This patch fixes that, while ensuring that every NV object
of TYPE_FLOAT has nv->precision set to a definite value.
The static precision values in the configuration table
are left as-is, dynamically modifying nv->precision in
created objects according to the mm/inches mode.

It also fixes a related problem, in which position changes
sometimes went unreported because of rollover boundary
issues.