### PR TITLE
Allow the polarity of the step pulse to be set.

### DIFF
--- a/g2core/board/G2v9/board_stepper.cpp
+++ b/g2core/board/G2v9/board_stepper.cpp
@@ -36,7 +36,7 @@ StepDirStepper<Motate::kSocket1_StepPinNumber,
                Motate::kSocket1_Microstep_1PinNumber,
                Motate::kSocket1_Microstep_2PinNumber,
                Motate::kSocket1_VrefPinNumber>
-    motor_1{};
+    motor_1{M1_STEP_POLARITY};
 
 StepDirStepper<Motate::kSocket2_StepPinNumber,
                Motate::kSocket2_DirPinNumber,
@@ -45,7 +45,7 @@ StepDirStepper<Motate::kSocket2_StepPinNumber,
                Motate::kSocket2_Microstep_1PinNumber,
                Motate::kSocket2_Microstep_2PinNumber,
                Motate::kSocket2_VrefPinNumber>
-    motor_2{};
+    motor_2{M2_STEP_POLARITY};
 
 StepDirStepper<Motate::kSocket3_StepPinNumber,
                Motate::kSocket3_DirPinNumber,
@@ -54,7 +54,7 @@ StepDirStepper<Motate::kSocket3_StepPinNumber,
                Motate::kSocket3_Microstep_1PinNumber,
                Motate::kSocket3_Microstep_2PinNumber,
                Motate::kSocket3_VrefPinNumber>
-    motor_3{};
+    motor_3{M3_STEP_POLARITY};
 
 StepDirStepper<Motate::kSocket4_StepPinNumber,
                Motate::kSocket4_DirPinNumber,
@@ -63,7 +63,7 @@ StepDirStepper<Motate::kSocket4_StepPinNumber,
                Motate::kSocket4_Microstep_1PinNumber,
                Motate::kSocket4_Microstep_2PinNumber,
                Motate::kSocket4_VrefPinNumber>
-    motor_4{};
+    motor_4{M4_STEP_POLARITY};
 
 // StepDirStepper<
 //    Motate::kSocket5_StepPinNumber,
@@ -72,7 +72,7 @@ StepDirStepper<Motate::kSocket4_StepPinNumber,
 //    Motate::kSocket5_Microstep_0PinNumber,
 //    Motate::kSocket5_Microstep_1PinNumber,
 //    Motate::kSocket5_Microstep_2PinNumber,
-//    Motate::kSocket5_VrefPinNumber> motor_5 {};
+//    Motate::kSocket5_VrefPinNumber> motor_5 {M5_STEP_POLARITY};
 
 // StepDirStepper<
 //    Motate::kSocket6_StepPinNumber,
@@ -81,7 +81,7 @@ StepDirStepper<Motate::kSocket4_StepPinNumber,
 //    Motate::kSocket6_Microstep_0PinNumber,
 //    Motate::kSocket6_Microstep_1PinNumber,
 //    Motate::kSocket6_Microstep_2PinNumber,
-//    Motate::kSocket6_VrefPinNumber> motor_6 {};
+//    Motate::kSocket6_VrefPinNumber> motor_6 {M6_STEP_POLARITY};
 
 Stepper* Motors[MOTORS] = {&motor_1, &motor_2, &motor_3, &motor_4};
 

--- a/g2core/config_app.cpp
+++ b/g2core/config_app.cpp
@@ -205,6 +205,7 @@ const cfgItem_t cfgArray[] = {
     { "1","1po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_1].polarity,       M1_POLARITY },
     { "1","1pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M1_POWER_MODE },
     { "1","1pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_1].power_level,    M1_POWER_LEVEL },
+    { "1","1ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_1].step_polarity,  M1_STEP_POLARITY },
 //  { "1","1pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_1].power_idle,     M1_POWER_IDLE },
 //  { "1","1mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_1].motor_timeout,  M1_MOTOR_TIMEOUT },
 #if (MOTORS >= 2)
@@ -216,6 +217,7 @@ const cfgItem_t cfgArray[] = {
     { "2","2po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_2].polarity,       M2_POLARITY },
     { "2","2pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M2_POWER_MODE },
     { "2","2pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_2].power_level,    M2_POWER_LEVEL},
+    { "2","2ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_2].step_polarity,  M2_STEP_POLARITY },
 //  { "2","2pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_2].power_idle,     M2_POWER_IDLE },
 //  { "2","2mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_2].motor_timeout,  M2_MOTOR_TIMEOUT },
 #endif
@@ -228,6 +230,7 @@ const cfgItem_t cfgArray[] = {
     { "3","3po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_3].polarity,       M3_POLARITY },
     { "3","3pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M3_POWER_MODE },
     { "3","3pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_3].power_level,    M3_POWER_LEVEL },
+    { "3","3ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_3].step_polarity,  M3_STEP_POLARITY },
 //  { "3","3pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_3].power_idle,     M3_POWER_IDLE },
 //  { "3","3mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_3].motor_timeout,  M3_MOTOR_TIMEOUT },
 #endif
@@ -240,6 +243,7 @@ const cfgItem_t cfgArray[] = {
     { "4","4po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_4].polarity,       M4_POLARITY },
     { "4","4pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M4_POWER_MODE },
     { "4","4pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_4].power_level,    M4_POWER_LEVEL },
+    { "4","4ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_4].step_polarity,  M4_STEP_POLARITY },
 //  { "4","4pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_4].power_idle,     M4_POWER_IDLE },
 //  { "4","4mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_4].motor_timeout,  M4_MOTOR_TIMEOUT },
 #endif
@@ -252,6 +256,7 @@ const cfgItem_t cfgArray[] = {
     { "5","5po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_5].polarity,       M5_POLARITY },
     { "5","5pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M5_POWER_MODE },
     { "5","5pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_5].power_level,    M5_POWER_LEVEL },
+    { "5","5ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_5].step_polarity,  M5_STEP_POLARITY },
 //  { "5","5pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_5].power_idle,     M5_POWER_IDLE },
 //  { "5","5mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_5].motor_timeout,  M5_MOTOR_TIMEOUT },
 #endif
@@ -264,6 +269,7 @@ const cfgItem_t cfgArray[] = {
     { "6","6po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_6].polarity,       M6_POLARITY },
     { "6","6pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M6_POWER_MODE },
     { "6","6pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_6].power_level,    M6_POWER_LEVEL },
+    { "6","6ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_6].step_polarity,  M6_STEP_POLARITY },
 //  { "6","6pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_6].power_idle,     M6_POWER_IDLE },
 //  { "6","6mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_6].motor_timeout,  M6_MOTOR_TIMEOUT },
 #endif

--- a/g2core/config_app.cpp
+++ b/g2core/config_app.cpp
@@ -205,7 +205,7 @@ const cfgItem_t cfgArray[] = {
     { "1","1po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_1].polarity,       M1_POLARITY },
     { "1","1pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M1_POWER_MODE },
     { "1","1pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_1].power_level,    M1_POWER_LEVEL },
-    { "1","1ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_1].step_polarity,  M1_STEP_POLARITY },
+    { "1","1sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M1_STEP_POLARITY },
 //  { "1","1pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_1].power_idle,     M1_POWER_IDLE },
 //  { "1","1mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_1].motor_timeout,  M1_MOTOR_TIMEOUT },
 #if (MOTORS >= 2)
@@ -217,7 +217,7 @@ const cfgItem_t cfgArray[] = {
     { "2","2po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_2].polarity,       M2_POLARITY },
     { "2","2pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M2_POWER_MODE },
     { "2","2pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_2].power_level,    M2_POWER_LEVEL},
-    { "2","2ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_2].step_polarity,  M2_STEP_POLARITY },
+    { "2","2sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M2_STEP_POLARITY },
 //  { "2","2pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_2].power_idle,     M2_POWER_IDLE },
 //  { "2","2mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_2].motor_timeout,  M2_MOTOR_TIMEOUT },
 #endif
@@ -230,7 +230,7 @@ const cfgItem_t cfgArray[] = {
     { "3","3po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_3].polarity,       M3_POLARITY },
     { "3","3pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M3_POWER_MODE },
     { "3","3pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_3].power_level,    M3_POWER_LEVEL },
-    { "3","3ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_3].step_polarity,  M3_STEP_POLARITY },
+    { "3","3sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M3_STEP_POLARITY },
 //  { "3","3pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_3].power_idle,     M3_POWER_IDLE },
 //  { "3","3mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_3].motor_timeout,  M3_MOTOR_TIMEOUT },
 #endif
@@ -243,7 +243,7 @@ const cfgItem_t cfgArray[] = {
     { "4","4po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_4].polarity,       M4_POLARITY },
     { "4","4pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M4_POWER_MODE },
     { "4","4pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_4].power_level,    M4_POWER_LEVEL },
-    { "4","4ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_4].step_polarity,  M4_STEP_POLARITY },
+    { "4","4sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M4_STEP_POLARITY },
 //  { "4","4pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_4].power_idle,     M4_POWER_IDLE },
 //  { "4","4mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_4].motor_timeout,  M4_MOTOR_TIMEOUT },
 #endif
@@ -256,7 +256,7 @@ const cfgItem_t cfgArray[] = {
     { "5","5po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_5].polarity,       M5_POLARITY },
     { "5","5pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M5_POWER_MODE },
     { "5","5pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_5].power_level,    M5_POWER_LEVEL },
-    { "5","5ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_5].step_polarity,  M5_STEP_POLARITY },
+    { "5","5sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M5_STEP_POLARITY },
 //  { "5","5pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_5].power_idle,     M5_POWER_IDLE },
 //  { "5","5mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_5].motor_timeout,  M5_MOTOR_TIMEOUT },
 #endif
@@ -269,7 +269,7 @@ const cfgItem_t cfgArray[] = {
     { "6","6po",_fip, 0, st_print_po, get_ui8, set_01,     &st_cfg.mot[MOTOR_6].polarity,       M6_POLARITY },
     { "6","6pm",_fip, 0, st_print_pm, st_get_pm,st_set_pm, &cs.null,                            M6_POWER_MODE },
     { "6","6pl",_fip, 3, st_print_pl, get_flt, st_set_pl,  &st_cfg.mot[MOTOR_6].power_level,    M6_POWER_LEVEL },
-    { "6","6ps",_fip, 0, st_print_ps, get_ui8, set_01,     &st_cfg.mot[MOTOR_6].step_polarity,  M6_STEP_POLARITY },
+    { "6","6sp",_fip, 0, st_print_sp, st_get_sp, st_set_sp,&cs.null,                            M6_STEP_POLARITY },
 //  { "6","6pi",_fip, 3, st_print_pi, get_flt, st_set_pi,  &st_cfg.mot[MOTOR_6].power_idle,     M6_POWER_IDLE },
 //  { "6","6mt",_fip, 2, st_print_mt, get_flt, st_set_mt,  &st_cfg.mot[MOTOR_6].motor_timeout,  M6_MOTOR_TIMEOUT },
 #endif

--- a/g2core/device/step_dir_driver/step_dir_driver.h
+++ b/g2core/device/step_dir_driver/step_dir_driver.h
@@ -62,7 +62,10 @@ struct StepDirStepper final : Stepper  {
     PWMOutputPin<vref_num> _vref;
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    StepDirStepper(bool invert_step, const uint32_t frequency = 250000) : Stepper{invert_step}, _vref{kNormal, frequency} {};
+    StepDirStepper(bool invert_step, const uint32_t frequency = 250000) : Stepper{invert_step}, _vref{kNormal, frequency} {
+	// Set stepper pin to resting state.
+	stepEnd();
+    }
 
     /* Optional override of init */
 

--- a/g2core/device/step_dir_driver/step_dir_driver.h
+++ b/g2core/device/step_dir_driver/step_dir_driver.h
@@ -62,7 +62,7 @@ struct StepDirStepper final : Stepper  {
     PWMOutputPin<vref_num> _vref;
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    StepDirStepper(const uint32_t frequency = 250000) : Stepper{}, _vref{kNormal, frequency} {};
+    StepDirStepper(bool invert_step, const uint32_t frequency = 250000) : Stepper{invert_step}, _vref{kNormal, frequency} {};
 
     /* Optional override of init */
 

--- a/g2core/device/step_dir_driver/step_dir_driver.h
+++ b/g2core/device/step_dir_driver/step_dir_driver.h
@@ -60,11 +60,23 @@ struct StepDirStepper final : Stepper  {
     OutputPin<ms1_num>     _ms1;
     OutputPin<ms2_num>     _ms2;
     PWMOutputPin<vref_num> _vref;
+    bool                   _invert_step;
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    StepDirStepper(bool invert_step, const uint32_t frequency = 250000) : Stepper{invert_step}, _vref{kNormal, frequency} {
+    StepDirStepper(bool invert_step, const uint32_t frequency = 250000) : _vref{kNormal, frequency}, _invert_step{invert_step} {
 	// Set stepper pin to resting state.
 	stepEnd();
+    }
+
+    void setStepPolarity(bool invert_step) override
+    {
+	_invert_step = invert_step;
+	stepEnd();
+    }
+
+    bool getStepPolarity() const override
+    {
+	return _invert_step;
     }
 
     /* Optional override of init */

--- a/g2core/device/step_dir_driver/step_dir_driver.h
+++ b/g2core/device/step_dir_driver/step_dir_driver.h
@@ -125,9 +125,19 @@ struct StepDirStepper final : Stepper  {
         }
     };
 
-    void stepStart() override { _step.set(); };
+    void stepStart() override {
+	if (_invert_step)
+	    _step.clear();
+	else
+	    _step.set();
+    };
 
-    void stepEnd() override { _step.clear(); };
+    void stepEnd() override {
+	if (_invert_step)
+	    _step.set();
+	else
+	    _step.clear();
+    };
 
     void setDirection(uint8_t new_direction) override {
         if (!_dir.isNull()) {

--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -227,7 +227,7 @@
 #define M1_POLARITY                 0                       // {1po:  0=normal direction, 1=inverted direction
 #endif
 #ifndef M1_STEP_POLARITY
-#define M1_STEP_POLARITY            0                       // {1ps:  0=pulse high, 1=pulse low
+#define M1_STEP_POLARITY            0	                    // {1sp:  0=pulse high, 1=pulse low
 #endif
 #ifndef M1_POWER_MODE
 #define M1_POWER_MODE               MOTOR_DISABLED          // {1pm:  MOTOR_DISABLED, MOTOR_ALWAYS_POWERED, MOTOR_POWERED_IN_CYCLE, MOTOR_POWERED_ONLY_WHEN_MOVING

--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -226,6 +226,9 @@
 #ifndef M1_POLARITY
 #define M1_POLARITY                 0                       // {1po:  0=normal direction, 1=inverted direction
 #endif
+#ifndef M1_STEP_POLARITY
+#define M1_STEP_POLARITY            0                       // {1ps:  0=pulse high, 1=pulse low
+#endif
 #ifndef M1_POWER_MODE
 #define M1_POWER_MODE               MOTOR_DISABLED          // {1pm:  MOTOR_DISABLED, MOTOR_ALWAYS_POWERED, MOTOR_POWERED_IN_CYCLE, MOTOR_POWERED_ONLY_WHEN_MOVING
 #endif
@@ -251,6 +254,9 @@
 #endif
 #ifndef M2_POLARITY
 #define M2_POLARITY                 0
+#endif
+#ifndef M2_STEP_POLARITY
+#define M2_STEP_POLARITY            0
 #endif
 #ifndef M2_POWER_MODE
 #define M2_POWER_MODE               MOTOR_DISABLED
@@ -278,6 +284,9 @@
 #ifndef M3_POLARITY
 #define M3_POLARITY                 1
 #endif
+#ifndef M3_STEP_POLARITY
+#define M3_STEP_POLARITY            0
+#endif
 #ifndef M3_POWER_MODE
 #define M3_POWER_MODE               MOTOR_DISABLED
 #endif
@@ -303,6 +312,9 @@
 #endif
 #ifndef M4_POLARITY
 #define M4_POLARITY                 0
+#endif
+#ifndef M4_STEP_POLARITY
+#define M4_STEP_POLARITY            0
 #endif
 #ifndef M4_POWER_MODE
 #define M4_POWER_MODE               MOTOR_DISABLED
@@ -330,6 +342,9 @@
 #ifndef M5_POLARITY
 #define M5_POLARITY                 0
 #endif
+#ifndef M5_STEP_POLARITY
+#define M5_STEP_POLARITY            0
+#endif
 #ifndef M5_POWER_MODE
 #define M5_POWER_MODE               MOTOR_DISABLED
 #endif
@@ -355,6 +370,9 @@
 #endif
 #ifndef M6_POLARITY
 #define M6_POLARITY                 0
+#endif
+#ifndef M6_STEP_POLARITY
+#define M6_STEP_POLARITY            0
 #endif
 #ifndef M6_POWER_MODE
 #define M6_POWER_MODE               MOTOR_DISABLED

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -691,9 +691,6 @@ stat_t st_prep_line(float travel_steps[], float following_error[], float segment
             continue;
         }
 
-	// Set step polarity
-	Motors[motor]->set_step_polarity(st_cfg.mot[motor].step_polarity);
-
         // Setup the direction, compensating for polarity.
         // Set the step_sign which is used by the stepper ISR to accumulate step position
 
@@ -1020,6 +1017,31 @@ stat_t st_get_pwr(nvObj_t *nv)
 	return (STAT_OK);
 }
 
+stat_t st_set_sp(nvObj_t *nv)            // set motor step polarity
+{
+    if (nv->value < 0) { return (STAT_INPUT_LESS_THAN_MIN_VALUE); }
+    if (nv->value > 1) { return (STAT_INPUT_EXCEEDS_MAX_VALUE); }
+
+    uint8_t motor = _get_motor(nv->index);
+    if (motor > MOTORS) { return STAT_INPUT_VALUE_RANGE_ERROR; };
+
+    Motors[motor]->setStepPolarity((int)nv->value);
+    return (STAT_OK);
+}
+
+stat_t st_get_sp(nvObj_t *nv)            // get motor step polarity
+{
+    if (nv->value < 0) { return (STAT_INPUT_LESS_THAN_MIN_VALUE); }
+    if (nv->value > 1) { return (STAT_INPUT_EXCEEDS_MAX_VALUE); }
+
+    uint8_t motor = _get_motor(nv->index);
+    if (motor > MOTORS) { return STAT_INPUT_VALUE_RANGE_ERROR; };
+
+    nv->value = (float)Motors[motor]->getStepPolarity();
+    nv->valuetype = TYPE_INT;
+    return (STAT_OK);
+}
+
 /* GLOBAL FUNCTIONS (SYSTEM LEVEL)
  *
  * st_set_mt() - set global motor timeout in seconds
@@ -1139,7 +1161,7 @@ void st_print_tr(nvObj_t *nv) { _print_motor_flt_units(nv, fmt_0tr, cm_get_units
 void st_print_mi(nvObj_t *nv) { _print_motor_int(nv, fmt_0mi);}
 void st_print_su(nvObj_t *nv) { _print_motor_flt_units(nv, fmt_0su, cm_get_units_mode(MODEL));}
 void st_print_po(nvObj_t *nv) { _print_motor_int(nv, fmt_0po);}
-void st_print_ps(nvObj_t *nv) { _print_motor_int(nv, fmt_0ps);}
+void st_print_sp(nvObj_t *nv) { _print_motor_int(nv, fmt_0ps);}
 void st_print_pm(nvObj_t *nv) { _print_motor_int(nv, fmt_0pm);}
 void st_print_pl(nvObj_t *nv) { _print_motor_flt(nv, fmt_0pl);}
 void st_print_pwr(nvObj_t *nv){ _print_motor_pwr(nv, fmt_pwr);}

--- a/g2core/stepper.cpp
+++ b/g2core/stepper.cpp
@@ -336,7 +336,7 @@ void dda_timer_type::interrupt()
         }
 #endif
 
-    // Process end of segment. 
+    // Process end of segment.
     // One more interrupt will occur to turn of any pulses set in this pass.
     if (--st_run.dda_ticks_downcount == 0) {
         _load_move();       // load the next move at the current interrupt level
@@ -451,7 +451,7 @@ static void _load_move()
 
 	// ...start motor power timeouts
 	//	for (uint8_t motor = MOTOR_1; motor < MOTORS; motor++) {
-	//		Motors[motor]->motionStopped();    
+	//		Motors[motor]->motionStopped();
 	//  }
 	// loop unrolled version
         motor_1.motionStopped();    // ...start motor power timeouts
@@ -626,7 +626,7 @@ static void _load_move()
         // handle synchronous commands
     } else if (st_pre.block_type == BLOCK_TYPE_COMMAND) {
         mp_runtime_command(st_pre.bf);
-        
+
     } // else null - which is okay in many cases
 
     // all other cases drop to here (e.g. Null moves after Mcodes skip to here)
@@ -690,6 +690,9 @@ stat_t st_prep_line(float travel_steps[], float following_error[], float segment
             st_pre.mot[motor].substep_increment = 0;        // substep increment also acts as a motor flag
             continue;
         }
+
+	// Set step polarity
+	Motors[motor]->set_step_polarity(st_cfg.mot[motor].step_polarity);
 
         // Setup the direction, compensating for polarity.
         // Set the step_sign which is used by the stepper ISR to accumulate step position
@@ -926,7 +929,7 @@ stat_t st_set_su(nvObj_t *nv)			// motor steps per unit (direct)
         if (cm_get_axis_type(nv->index) == AXIS_TYPE_LINEAR) {
             nv->value *= INCHES_PER_MM;
         }
-    } 
+    }
     set_flt(nv);
     st_cfg.mot[m].units_per_step = 1.0/st_cfg.mot[m].steps_per_unit;
 
@@ -942,14 +945,14 @@ stat_t st_set_pm(nvObj_t *nv)            // set motor power mode
         nv->valuetype = TYPE_NULL;
         return (STAT_INPUT_LESS_THAN_MIN_VALUE);
     }
-    if (nv->value >= MOTOR_POWER_MODE_MAX_VALUE) { 
+    if (nv->value >= MOTOR_POWER_MODE_MAX_VALUE) {
         nv->valuetype = TYPE_NULL;
-        return (STAT_INPUT_EXCEEDS_MAX_VALUE); 
+        return (STAT_INPUT_EXCEEDS_MAX_VALUE);
     }
     uint8_t motor = _get_motor(nv->index);
     if (motor > MOTORS) {
         nv->valuetype = TYPE_NULL;
-        return STAT_INPUT_VALUE_RANGE_ERROR; 
+        return STAT_INPUT_VALUE_RANGE_ERROR;
     };
 
     // We do this *here* in order for this to take effect immediately.
@@ -963,7 +966,7 @@ stat_t st_get_pm(nvObj_t *nv)            // get motor power mode
     uint8_t motor = _get_motor(nv->index);
     if (motor > MOTORS) {
         nv->valuetype = TYPE_NULL;
-        return STAT_INPUT_VALUE_RANGE_ERROR; 
+        return STAT_INPUT_VALUE_RANGE_ERROR;
     };
 
     nv->value = (float)Motors[motor]->getPowerMode();
@@ -982,7 +985,7 @@ stat_t st_set_pl(nvObj_t *nv)    // motor power level
 {
     if (nv->value < (float)0.0) {
         nv->valuetype = TYPE_NULL;
-        return (STAT_INPUT_LESS_THAN_MIN_VALUE); 
+        return (STAT_INPUT_LESS_THAN_MIN_VALUE);
     }
     if (nv->value > (float)1.0) {
         nv->valuetype = TYPE_NULL;
@@ -1044,7 +1047,7 @@ stat_t st_set_mt(nvObj_t *nv)
 
 // Make sure this function is not part of initialization --> f00
 // nv->value is seconds of timeout
-stat_t st_set_me(nvObj_t *nv)    
+stat_t st_set_me(nvObj_t *nv)
 {
     for (uint8_t motor = MOTOR_1; motor < MOTORS; motor++) {
         Motors[motor]->enable(nv->value);   // nv->value is the timeout or 0 for default
@@ -1054,7 +1057,7 @@ stat_t st_set_me(nvObj_t *nv)
 
 // Make sure this function is not part of initialization --> f00
 // nv-value is motor to disable, or 0 for all motors
-stat_t st_set_md(nvObj_t *nv)    
+stat_t st_set_md(nvObj_t *nv)
 {
     if (nv->value < 0) {
         nv->valuetype = TYPE_NULL;
@@ -1063,7 +1066,7 @@ stat_t st_set_md(nvObj_t *nv)
     if (nv->value > MOTORS) {
         nv->valuetype = TYPE_NULL;
         return (STAT_INPUT_EXCEEDS_MAX_VALUE);
-    }    
+    }
     // de-energize all motors
     if ((uint8_t)nv->value == 0) {      // 0 means all motors
         for (uint8_t motor = MOTOR_1; motor < MOTORS; motor++) {
@@ -1097,6 +1100,7 @@ static const char fmt_0tr[] = "[%s%s] m%s travel per revolution%10.4f%s\n";
 static const char fmt_0mi[] = "[%s%s] m%s microsteps%16d [1,2,4,8,16,32]\n";
 static const char fmt_0su[] = "[%s%s] m%s steps per unit %17.5f steps per%s\n";
 static const char fmt_0po[] = "[%s%s] m%s polarity%18d [0=normal,1=reverse]\n";
+static const char fmt_0ps[] = "[%s%s] m%s step polarity%13d [0=normal,1=reverse]\n";
 static const char fmt_0pm[] = "[%s%s] m%s power management%10d [0=disabled,1=always on,2=in cycle,3=when moving]\n";
 static const char fmt_0pl[] = "[%s%s] m%s motor power level%13.3f [0.000=minimum, 1.000=maximum]\n";
 static const char fmt_pwr[] = "[%s%s] Motor %c power level:%12.3f\n";
@@ -1135,6 +1139,7 @@ void st_print_tr(nvObj_t *nv) { _print_motor_flt_units(nv, fmt_0tr, cm_get_units
 void st_print_mi(nvObj_t *nv) { _print_motor_int(nv, fmt_0mi);}
 void st_print_su(nvObj_t *nv) { _print_motor_flt_units(nv, fmt_0su, cm_get_units_mode(MODEL));}
 void st_print_po(nvObj_t *nv) { _print_motor_int(nv, fmt_0po);}
+void st_print_ps(nvObj_t *nv) { _print_motor_int(nv, fmt_0ps);}
 void st_print_pm(nvObj_t *nv) { _print_motor_int(nv, fmt_0pm);}
 void st_print_pl(nvObj_t *nv) { _print_motor_flt(nv, fmt_0pl);}
 void st_print_pwr(nvObj_t *nv){ _print_motor_pwr(nv, fmt_pwr);}

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -354,6 +354,7 @@ typedef struct cfgMotor {                   // per-motor configs
     uint8_t motor_map;                      // map motor to axis
     uint8_t microsteps;                     // microsteps to apply for each axis (ex: 8)
     uint8_t polarity;                       // 0=normal polarity, 1=reverse motor direction
+    uint8_t step_polarity;                  // 0=normal polarity (normally low, step pulse high), 1=reverse polarity
     float power_level;                      // set 0.000 to 1.000 for PMW vref setting
     float step_angle;                       // degrees per whole step (ex: 1.8)
     float travel_rev;                       // mm or deg of travel per motor revolution
@@ -434,13 +435,16 @@ struct Stepper {
     uint32_t _motor_disable_timeout_ms;     // the number of ms that the timeout is reset to
     stPowerState _power_state;              // state machine for managing motor power
     stPowerMode _power_mode;                // See stPowerMode for values
+	bool _invert_step;                  // Invert the step output (where applicable)
 
     /* stepper default values */
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    Stepper(const uint32_t frequency = 500000)
+    Stepper(const uint32_t frequency = 500000) : _invert_step(false)
     {
     };
+
+    void set_step_polarity(bool invert_step) { _invert_step = invert_step; }
 
     /* Functions that handle all motor functions (calls virtuals if needed) */
 
@@ -471,7 +475,7 @@ struct Stepper {
         }
         if (_power_state == MOTOR_IDLE) {
             return (0.0);
-        }        
+        }
         return (st_cfg.mot[motor].power_level);
     };
 
@@ -479,7 +483,7 @@ struct Stepper {
 //    {
 //        return (_power_mode == MOTOR_DISABLED);
 //    };
-    
+
     // turn on motor in all cases unless it's disabled
     // NOTE: in the future the default assigned timeout will be the motor's default value
     void enable(float timeout = st_cfg.motor_power_timeout)
@@ -506,7 +510,7 @@ struct Stepper {
         _motor_disable_timeout.clear();
         _power_state = MOTOR_IDLE; // or MOTOR_OFF
     };
-    
+
     // turn off motor is only powered when moving
     void motionStopped() {
         if (_power_mode == MOTOR_POWERED_IN_CYCLE) {
@@ -518,7 +522,7 @@ struct Stepper {
             }
         }
     };
-    
+
     virtual void periodicCheck(bool have_actually_stopped) // can be overridden
     {
         if (have_actually_stopped && _power_state == MOTOR_RUNNING) {
@@ -602,6 +606,7 @@ stat_t st_set_me(nvObj_t *nv);
     void st_print_mi(nvObj_t *nv);
     void st_print_su(nvObj_t *nv);
     void st_print_po(nvObj_t *nv);
+    void st_print_ps(nvObj_t *nv);
     void st_print_pm(nvObj_t *nv);
     void st_print_pl(nvObj_t *nv);
     void st_print_pwr(nvObj_t *nv);

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -434,25 +434,13 @@ struct Stepper {
     uint32_t _motor_disable_timeout_ms;     // the number of ms that the timeout is reset to
     stPowerState _power_state;              // state machine for managing motor power
     stPowerMode _power_mode;                // See stPowerMode for values
-    bool _invert_step;                      // Invert the step output (where applicable)
 
     /* stepper default values */
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    Stepper(bool invert_step, const uint32_t frequency = 500000) : _invert_step(invert_step)
+    Stepper(const uint32_t frequency = 500000)
     {
     };
-
-    void setStepPolarity(bool invert_step)
-    {
-	_invert_step = invert_step;
-	stepEnd();
-    }
-
-    bool getStepPolarity() const
-    {
-	return _invert_step;
-    }
 
     /* Functions that handle all motor functions (calls virtuals if needed) */
 
@@ -555,6 +543,9 @@ struct Stepper {
             }
         }
     };
+
+    virtual bool getStepPolarity() const { return false; }
+    virtual void setStepPolarity(bool invert_step) {}
 
     /* Functions that must be implemented in subclasses */
 

--- a/g2core/stepper.h
+++ b/g2core/stepper.h
@@ -354,7 +354,6 @@ typedef struct cfgMotor {                   // per-motor configs
     uint8_t motor_map;                      // map motor to axis
     uint8_t microsteps;                     // microsteps to apply for each axis (ex: 8)
     uint8_t polarity;                       // 0=normal polarity, 1=reverse motor direction
-    uint8_t step_polarity;                  // 0=normal polarity (normally low, step pulse high), 1=reverse polarity
     float power_level;                      // set 0.000 to 1.000 for PMW vref setting
     float step_angle;                       // degrees per whole step (ex: 1.8)
     float travel_rev;                       // mm or deg of travel per motor revolution
@@ -435,16 +434,25 @@ struct Stepper {
     uint32_t _motor_disable_timeout_ms;     // the number of ms that the timeout is reset to
     stPowerState _power_state;              // state machine for managing motor power
     stPowerMode _power_mode;                // See stPowerMode for values
-	bool _invert_step;                  // Invert the step output (where applicable)
+    bool _invert_step;                      // Invert the step output (where applicable)
 
     /* stepper default values */
 
     // sets default pwm freq for all motor vrefs (commented line below also sets HiZ)
-    Stepper(const uint32_t frequency = 500000) : _invert_step(false)
+    Stepper(bool invert_step, const uint32_t frequency = 500000) : _invert_step(invert_step)
     {
     };
 
-    void set_step_polarity(bool invert_step) { _invert_step = invert_step; }
+    void setStepPolarity(bool invert_step)
+    {
+	_invert_step = invert_step;
+	stepEnd();
+    }
+
+    bool getStepPolarity() const
+    {
+	return _invert_step;
+    }
 
     /* Functions that handle all motor functions (calls virtuals if needed) */
 
@@ -593,6 +601,8 @@ stat_t st_set_pm(nvObj_t *nv);
 stat_t st_get_pm(nvObj_t *nv);
 stat_t st_set_pl(nvObj_t *nv);
 stat_t st_get_pwr(nvObj_t *nv);
+stat_t st_set_sp(nvObj_t *nv);
+stat_t st_get_sp(nvObj_t *nv);
 
 stat_t st_set_mt(nvObj_t *nv);
 stat_t st_set_md(nvObj_t *nv);
@@ -606,7 +616,7 @@ stat_t st_set_me(nvObj_t *nv);
     void st_print_mi(nvObj_t *nv);
     void st_print_su(nvObj_t *nv);
     void st_print_po(nvObj_t *nv);
-    void st_print_ps(nvObj_t *nv);
+    void st_print_sp(nvObj_t *nv);
     void st_print_pm(nvObj_t *nv);
     void st_print_pl(nvObj_t *nv);
     void st_print_pwr(nvObj_t *nv);


### PR DESCRIPTION
Note: my editor removes trailing whitespace automatically, hence all the changes that delete it.

This fixes a problem with TB6560 stepper drivers, which miss steps if the step pulse is positive.
