### PR TITLE
Update A, B, C axes radius defaults to use motors 4, 5, & 6

### DIFF
--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -524,7 +524,7 @@
  * Note that you need floating point values to always have a .0 at the end!
 
 #define A_AXIS_MODE                 AXIS_RADIUS
-#define A_RADIUS                    (M1_TRAVEL_PER_REV/(2*3.14159628))
+#define A_RADIUS                    (M4_TRAVEL_PER_REV/(2*3.14159628))
 #define A_VELOCITY_MAX              ((X_VELOCITY_MAX/M1_TRAVEL_PER_REV)*360) // set to the same speed as X axis
 #define A_FEEDRATE_MAX              A_VELOCITY_MAX
 #define A_TRAVEL_MIN                -1.0                                     // min/max the same means infinite, no limit
@@ -545,7 +545,7 @@
 #define A_AXIS_MODE                 AXIS_DISABLED
 #endif
 #ifndef A_RADIUS
-#define A_RADIUS                    (M1_TRAVEL_PER_REV/(2*3.14159628))
+#define A_RADIUS                    (M4_TRAVEL_PER_REV/(2*3.14159628))
 #endif
 #ifndef A_VELOCITY_MAX
 #define A_VELOCITY_MAX              ((X_VELOCITY_MAX/M1_TRAVEL_PER_REV)*360) // set to the same speed as X axis
@@ -589,7 +589,7 @@
 #define B_AXIS_MODE                 AXIS_DISABLED
 #endif
 #ifndef B_RADIUS
-#define B_RADIUS                    (M1_TRAVEL_PER_REV/(2*3.14159628))
+#define B_RADIUS                    (M5_TRAVEL_PER_REV/(2*3.14159628))
 #endif
 #ifndef B_VELOCITY_MAX
 #define B_VELOCITY_MAX              ((X_VELOCITY_MAX/M1_TRAVEL_PER_REV)*360)
@@ -616,10 +616,10 @@
 #define B_HOMING_DIRECTION          0
 #endif
 #ifndef B_SEARCH_VELOCITY
-#define B_SEARCH_VELOCITY           (A_VELOCITY_MAX * 0.500)
+#define B_SEARCH_VELOCITY           (B_VELOCITY_MAX * 0.500)
 #endif
 #ifndef B_LATCH_VELOCITY
-#define B_LATCH_VELOCITY            (A_VELOCITY_MAX * 0.100)
+#define B_LATCH_VELOCITY            (B_VELOCITY_MAX * 0.100)
 #endif
 #ifndef B_LATCH_BACKOFF
 #define B_LATCH_BACKOFF             5.0
@@ -633,7 +633,7 @@
 #define C_AXIS_MODE                 AXIS_DISABLED
 #endif
 #ifndef C_RADIUS
-#define C_RADIUS                    (M1_TRAVEL_PER_REV/(2*3.14159628))
+#define C_RADIUS                    (M6_TRAVEL_PER_REV/(2*3.14159628))
 #endif
 #ifndef C_VELOCITY_MAX
 #define C_VELOCITY_MAX              ((X_VELOCITY_MAX/M1_TRAVEL_PER_REV)*360)
@@ -660,10 +660,10 @@
 #define C_HOMING_DIRECTION          0
 #endif
 #ifndef C_SEARCH_VELOCITY
-#define C_SEARCH_VELOCITY           (A_VELOCITY_MAX * 0.500)
+#define C_SEARCH_VELOCITY           (C_VELOCITY_MAX * 0.500)
 #endif
 #ifndef C_LATCH_VELOCITY
-#define C_LATCH_VELOCITY            (A_VELOCITY_MAX * 0.100)
+#define C_LATCH_VELOCITY            (C_VELOCITY_MAX * 0.100)
 #endif
 #ifndef C_LATCH_BACKOFF
 #define C_LATCH_BACKOFF             5.0


### PR DESCRIPTION
As per issue #134