### PR TITLE
Fix coolant-init (partly fixes #336)

### DIFF
--- a/g2core/main.cpp
+++ b/g2core/main.cpp
@@ -30,6 +30,7 @@
 #include "report.h"
 #include "planner.h"
 #include "stepper.h"
+#include "coolant.h"
 #include "encoder.h"
 #include "spindle.h"
 #include "temperature.h"
@@ -118,6 +119,8 @@ void application_init_startup(void)
     canonical_machine_reset();
     spindle_init();                 // should be after PWM and canonical machine inits and config_init()
     spindle_reset();
+    coolant_init();
+    coolant_reset();
     temperature_init();
     gpio_reset();
 }


### PR DESCRIPTION
The coolant-I/Os are currently not initialized. Fix this by adding coolant_init/coolant_reset to the initialization-functions. Fixes #336 part 1.