### PR TITLE
Issue 357 settings xxx.h parameters

### DIFF
--- a/g2core/config.cpp
+++ b/g2core/config.cpp
@@ -128,7 +128,8 @@ static void _set_defa(nvObj_t *nv, bool print)
     cm_set_units_mode(MILLIMETERS);             // must do inits in MM mode
     for (nv->index=0; nv_index_is_single(nv->index); nv->index++) {
         if (cfgArray[nv->index].flags & F_INITIALIZE) {
-            if ((cfgArray[nv->index].flags & F_TYPE_MASK) == TYPE_INTEGER) {
+            if ((cfgArray[nv->index].flags & TYPE_INTEGER) ||
+                (cfgArray[nv->index].flags & TYPE_BOOLEAN)) {    // Fix for Issue #357
                 nv->value_int = cfgArray[nv->index].def_value;
             } else {
                 nv->value_flt = cfgArray[nv->index].def_value;

--- a/g2core/g2core_info.h
+++ b/g2core/g2core_info.h
@@ -21,7 +21,7 @@
 #ifndef G2CORE_INFO_H_ONCE
 #define G2CORE_INFO_H_ONCE
 
-#define G2CORE_FIRMWARE_BUILD			101.03  // Added stepper polarity {1pl:n}
+#define G2CORE_FIRMWARE_BUILD			101.03  // Issue #320, #354 - Added stepper polarity {1pl:n},  Fixed SR setting bug
 #define G2CORE_FIRMWARE_VERSION         0.99
 
 #ifdef GIT_VERSION


### PR DESCRIPTION
Fix for default settings being set incorrectly. Default loader was not properly interpreting settings labeled as TYPE_BOOLEAN.