### PR TITLE
Add M400 dummy command for Octoprint workaround

### DIFF
--- a/g2core/gcode_parser.cpp
+++ b/g2core/gcode_parser.cpp
@@ -779,7 +779,7 @@ static stat_t _parse_gcode_block(char *buf, char *active_comment)
             break;
 
             case 'M':
-            switch((uint8_t)value) {
+            switch((uint16_t)value) {
                 case 0: case 1: case 60:
                         SET_MODAL (MODAL_GROUP_M4, program_flow, PROGRAM_STOP);
                 case 2: case 30:
@@ -840,6 +840,7 @@ static stat_t _parse_gcode_block(char *buf, char *active_comment)
 
                 case 115: SET_NON_MODAL (next_action, NEXT_ACTION_MARLIN_REPORT_VERSION);   // report version information
                 case 117: status = STAT_COMPLETE; break;  //SET_NON_MODAL (next_action, NEXT_ACTION_MARLIN_DISPLAY_ON_SCREEN);
+                case 400: status = STAT_COMPLETE; break; // Workaround for OctoPrint. 
 #endif // MARLIN_COMPAT_ENABLED
 
                 default: status = STAT_MCODE_COMMAND_UNSUPPORTED;

--- a/g2core/marlin_compatibility.cpp
+++ b/g2core/marlin_compatibility.cpp
@@ -406,14 +406,14 @@ stat_t marlin_report_version()
     char buffer[128];
     char *str = buffer;
 
-    str_concat(str, "ok FIRMWARE_NAME:Marlin g2core-");
+    str_concat(str, "ok FIRMWARE_NAME:Marlin g2core-vegetablejedi-");
     str_concat(str, G2CORE_FIRMWARE_BUILD_STRING);
     *str = 0;
     xio_writeline(buffer);
     str = buffer;
     *str = 0;
 
-    str_concat(str, " SOURCE_CODE_URL:https://github.com/synthetos/g2");
+    str_concat(str, " SOURCE_CODE_URL:https://github.com/synthetos/g2, https://github.com/vegetablejedi/g2");
     *str = 0;
     xio_writeline(buffer);
     str = buffer; *str = 0;

--- a/g2core/scripts/build-printrbot-simple-pro.sh
+++ b/g2core/scripts/build-printrbot-simple-pro.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+MAKECMD='make CONFIG=PrintrbotSimple1608'
+
+if [ "$1" == "clean" ]; then
+    ${MAKECMD} clean
+    exit 0
+fi
+
+${MAKECMD} clean
+${MAKECMD}
+

--- a/g2core/scripts/flash-printrbot-simple-pro.sh
+++ b/g2core/scripts/flash-printrbot-simple-pro.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+FWFILE=$1
+
+if [ "${FWFILE}" == "" ]; then
+    FWFILE=./bin/PrintrbotSimple1608-printrboardG2v3/g2core.bin
+fi
+
+if [ ! -e ${FWFILE} ]; then
+    echo "Error: Firmware file is not exist"
+    exit 1
+fi
+
+BOSSAC=`which bossac`
+if [ "${BOSSAC}" == "" ]; then
+    echo "Error: bossac is not installed. Install bossa-cli package first."
+    exit 1
+fi
+
+set -x
+PORT=ttyACM0
+
+stty -F /dev/ttyACM0 1200 hup
+sleep 1
+
+stty -F /dev/ttyACM0 9600
+sleep 3
+
+${BOSSAC}  --port=ttyACM0  -U true -e -w -v -i -b -R ${FWFILE}
+
+echo ""
+
+if [ "$?" != "0" ]; then
+    echo "Error: Flashing firmware has been failed. Reset the printer and retry firmware flashing."
+    exit 1
+fi
+
+echo "Flashing firmware has been accomplished."
+echo "Reset the printer manually."
+
+exit 0
+


### PR DESCRIPTION
- Octoprint calls M400 every printing job is ended.
- Fixed an issue where the M400 command was not implemented and disconnected each time.