### PR TITLE
Fix #367 - Status report with wrong stat

### DIFF
--- a/g2core/gcode_parser.cpp
+++ b/g2core/gcode_parser.cpp
@@ -926,8 +926,6 @@ stat_t _execute_gcode_block(char *active_comment)
 {
     stat_t status = STAT_OK;
 
-    cm_cycle_start();   // any G, M or other word will autostart cycle if not already started
-
     if (gf.linenum) {
         cm_set_model_linenum(gv.linenum);
     }


### PR DESCRIPTION
Fix for #367 : The addition of cm_cycle_start() to the beginning of _execute_gcode_block() in commit ae0145c2 (which was described as "commentary and naming changes") broke state management.  With that addition, nearly every G and M code, except for G0, G1, G2, G3, causes a transition to state 5 (RUN) with no corresponding transition back afterwards.  In fact, even G0 .. G3 are broken in some cases - if one of those Gcodes is rejected due to a bad or missing argument (e.g. no axis words), state transitions to RUN and sticks.

There is some rationale for that change from the discussion on the issue:

> if the machine was not in a cycle and you send any gcode, it will automatically start one. Since we don’t wait for the user to push a “cycle start” button we automatically start a cycle when we see any gcode

I'm unconvinced by that argument, because, in the context of a g2core-based system where the UI is managed by a different program, "cycle start" results in one of two actions:

- The UI begins sending GCode, e.g. from a file, to g2core
- If the system is in feedhold state, feedhold is canceled and program execution resumes

So "cycle start" from the user standpoint is handled by the UI or "gcode sender", not by g2core. There is no need to switch to RUN state in order to simply execute non-motion GCode.  g2core does the right thing without the errant cm_cycle_start()

The removal of this line completely fixed my system which is based on CNCjs and g2core.  My system worked well using version 100.x and, prior to this fix, failed horribly with 101.
