### PR TITLE
Fixed race condition between `mp_exec_move` and `mp_aline`

### DIFF
--- a/g2core/planner.cpp
+++ b/g2core/planner.cpp
@@ -808,7 +808,7 @@ void mp_commit_write_buffer(const blockType block_type)
 }
 
 // Note: mp_get_run_buffer() is only called by mp_exec_move(), which is inside an interrupt
-// EMPTY is the one case where nothing is returned. This is not an error
+// EMPTY and INITALIZING are the two cases where nothing is returned. This is not an error
 // Otherwise return the buffer. Let mp_exec_move() manage the state machine to sort out:
 //  (1) is the the first time the run buffer has been retrieved?
 //  (2) is the buffer in error - i.e. not yet ready for running?
@@ -816,7 +816,7 @@ mpBuf_t * mp_get_run_buffer()
 {
     mpBuf_t *r = mp->q.r;
 
-    if (r->buffer_state == MP_BUFFER_EMPTY) {
+    if (r->buffer_state == MP_BUFFER_EMPTY || r->buffer_state == MP_BUFFER_INITIALIZING) {
         return (NULL);
     }
     return (r);

--- a/g2core/planner.h
+++ b/g2core/planner.h
@@ -174,8 +174,6 @@ typedef enum {                      // bf->buffer_state values in incresing orde
     MP_BUFFER_BACK_PLANNED,         // buffer ready for final planning; velocities have been set
     MP_BUFFER_FULLY_PLANNED,        // buffer fully planned. May still be replanned
     MP_BUFFER_RUNNING,              // current running buffer
-    MP_BUFFER_POLAND,               // Hitler used Poland as a buffer state
-    MP_BUFFER_UKRAINE               // Later Stalin did the same to Ukraine
 } bufferState;
 
 typedef enum {                      // bf->block_type values


### PR DESCRIPTION
There exists a race condition between `mp_exec_move` and `mp_aline`.
When `mp_aline` is modifying a buffer it is possible for the timer interrupt to trigger `mp_exec_move` halfway though the buffer being constructed.

This should be guarded against by using `mp_commit_write_buffer` however, `mp_get_run_buffer` does not properly check if it able to get the run buffer, if the buffer remaining is the one being written to. Both `MP_BUFFER_EMPTY` and `MP_BUFFER_INITIALIZING` both indicate that the buffer should not be used. 

Fixes #396 

Also, while I was investigating the bug, I discovered a nazi related joke, which as a person of Polish decent, I find distasteful and have removed it.

Signed-off-by: Sebastian Goscik <sebastian.goscik@arm.com>