### PR TITLE
Fix 404 url for SMW3D R7 CNC

### DIFF
--- a/g2core/boards.mk
+++ b/g2core/boards.mk
@@ -194,7 +194,7 @@ endif
 
 ##########
 # SMW3D r7 config:
-# https://www.smw3d.com/r7-cnc-diy-kit/
+# https://sites.google.com/site/smw3dr7/
 
 ifeq ("$(CONFIG)","r7")
     ifeq ("$(BOARD)","NONE")


### PR DESCRIPTION
The existing website is offline, and doesn't appear to be captured decently in the Wayback machine.

This Google Sites version is the best replacement link I've found (thus far).