### PR TITLE
Bug fix for rotary axis homing travel distance

### DIFF
--- a/g2core/cycle_homing.cpp
+++ b/g2core/cycle_homing.cpp
@@ -236,7 +236,7 @@ static stat_t _homing_axis_start(int8_t axis) {
 
     // Calculate and test travel distance
     float travel_distance;
-    if (((cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
+    if ((fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
         // For cyclic rotary axes, we set the travel distance to one full rotation
         travel_distance = 360.0;
     } else {

--- a/g2core/cycle_homing.cpp
+++ b/g2core/cycle_homing.cpp
@@ -234,8 +234,15 @@ static stat_t _homing_axis_start(int8_t axis) {
         return (_homing_error_exit(axis, STAT_HOMING_ERROR_ZERO_LATCH_VELOCITY));
     }
 
-    // calculate and test travel distance
-    float travel_distance = fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) + cm->a[axis].latch_backoff;
+    // Calculate and test travel distance
+    float travel_distance;
+    if (((cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
+        // For cyclic rotary axes, we set the travel distance to one full rotation
+        travel_distance = 360.0;
+    } else {
+        // All other axes use a calculated value
+        travel_distance = fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) + cm->a[axis].latch_backoff;
+    }
     if (fp_ZERO(travel_distance)) {
         return (_homing_error_exit(axis, STAT_HOMING_ERROR_TRAVEL_MIN_MAX_IDENTICAL));
     }


### PR DESCRIPTION
This fixes the problem in #435, whereby a rotary axis with identical travel min/max values wasn't being given a full table rotation worth of travel for testing the homing position.