### PR TITLE
Cyclic rotary axes are at pos 0.0 after homing

### DIFF
--- a/g2core/cycle_homing.cpp
+++ b/g2core/cycle_homing.cpp
@@ -337,7 +337,7 @@ static stat_t _homing_axis_setpoint_backoff(int8_t axis)  //
 static stat_t _homing_axis_set_position(int8_t axis)
 {
     if (hm.set_coordinates) {
-        if (((cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
+        if ((fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
             // Cyclic rotary axes should be set to position 0.0 at the end of homing
             cm_set_position_by_axis(axis, 0.0);
         } else {

--- a/g2core/cycle_homing.cpp
+++ b/g2core/cycle_homing.cpp
@@ -337,7 +337,13 @@ static stat_t _homing_axis_setpoint_backoff(int8_t axis)  //
 static stat_t _homing_axis_set_position(int8_t axis)
 {
     if (hm.set_coordinates) {
-        cm_set_position_by_axis(axis, hm.setpoint);
+        if (((cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
+            // Cyclic rotary axes should be set to position 0.0 at the end of homing
+            cm_set_position_by_axis(axis, 0.0);
+        } else {
+            // All other axes should be set to the set point (travel min) at the end of homing
+            cm_set_position_by_axis(axis, hm.setpoint);
+        }
         cm->homed[axis] = true;
 
     } else {  // handle G28.4 cycle - set position to the point of switch closure


### PR DESCRIPTION
This fixes a problem whereby cyclic rotary axes (eg min and max both == `-1`) report their position after homing as whatever the value of travel_min is.  eg `-1` in my case.

With this patch, they'll now (correctly) report their position as `0.0` after homing.