### PR TITLE
Update default settings to not use SPINDLE_ACTIVE_HIGH any more

### DIFF
--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -86,7 +86,7 @@
 #endif
 
 #ifndef SPINDLE_ENABLE_POLARITY
-#define SPINDLE_ENABLE_POLARITY     SPINDLE_ACTIVE_HIGH  // {spep: 0=active low, 1=active high
+#define SPINDLE_ENABLE_POLARITY     1       // {spep: 0=active low, 1=active high
 #endif
 
 #ifndef SPINDLE_DIR_POLARITY


### PR DESCRIPTION
This fixes the compilation problem that occurs when no `SPINDLE_ENABLE_POLARITY` value is defined in a given settings file.