### PR TITLE
Fix incorrect check for AXIS_RADIUS when homing cyclic rotary axis

### DIFF
--- a/g2core/cycle_homing.cpp
+++ b/g2core/cycle_homing.cpp
@@ -236,7 +236,7 @@ static stat_t _homing_axis_start(int8_t axis) {
 
     // Calculate and test travel distance
     float travel_distance;
-    if ((fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_RADIUS)) {
+    if ((fabs(cm->a[axis].travel_max - cm->a[axis].travel_min) < EPSILON) && (cm->a[axis].axis_mode == AXIS_STANDARD)) {
         // For cyclic rotary axes, we set the travel distance to one full rotation
         travel_distance = 360.0;
     } else {


### PR DESCRIPTION
This bug was due to a misunderstanding of what AXIS_RADIUS means.