### PR TITLE
Ensure json_serialize generates valid json when handling empty objects

### DIFF
--- a/g2core/json_parser.cpp
+++ b/g2core/json_parser.cpp
@@ -400,8 +400,6 @@ static stat_t _get_nv_pair(nvObj_t *nv, char **pstr, int8_t *depth)
  *    - Allow self-referential elements that would otherwise cause a recursive loop
  *    - Skip over empty objects (TYPE_EMPTY)
  *    - If a JSON object is empty represent it as {}
- *      --- OR ---
- *    - If a JSON object is empty omit the object altogether (no curlies)
  */
 
 uint16_t json_serialize(nvObj_t *nv, char *out_buf, uint16_t size)
@@ -430,6 +428,7 @@ uint16_t json_serialize(nvObj_t *nv, char *out_buf, uint16_t size)
                                     }
                 case (TYPE_PARENT): {   *str++ = '{';
                                         need_a_comma = false;
+                                        prev_depth++; // make sure empty objects are closed
                                         break;
                                     }
                 case (TYPE_FLOAT):  {   convert_outgoing_float(nv);


### PR DESCRIPTION
Ensure json serializer generates valid json when handling empty objects (previously generated unmatched brace).