### PR TITLE
Fix status report race condition

### DIFF
--- a/g2core/report.cpp
+++ b/g2core/report.cpp
@@ -337,17 +337,18 @@ stat_t sr_status_report_callback()         // called by controller dispatcher
         return (STAT_NOOP);
     }
 
-   // don't send an SR if you the planner is experiencing a time constraint
-   if (!mp_is_phat_city_time()) {
+    // don't send an SR if you the planner is experiencing a time constraint
+    if (!mp_is_phat_city_time()) {
         if (++sr.throttle_counter != SR_THROTTLE_COUNT) {
             return (STAT_NOOP);
         }
         sr.throttle_counter = 0;
     }
 
-    sr.status_report_request = SR_OFF;
+    srVerbosity req_sr_verbosity = sr.status_report_request;
     sr.status_report_systick.clear();
-    if ((sr.status_report_request == SR_VERBOSE) ||
+    sr.status_report_request = SR_OFF;
+    if ((req_sr_verbosity == SR_VERBOSE) ||
         (sr.status_report_verbosity == SR_VERBOSE)) {
         _populate_unfiltered_status_report();
     } else {


### PR DESCRIPTION
This fixes a race condition that results in status reports being nonfunctional until a device reset.  The race condition occurs in the following circumstances:

1. A status report is requested via `sr_request_status_report()`, setting `sr.status_report_request` to a value other than `SR_OFF`, and setting `sr.status_report_systick` to a value in the (near) future.
2. The main loop calls `sr_status_report_callback()`.
3. `sr_status_report_callback()` sets `sr.status_report_request` to `SR_OFF` (as it should in normal circumstances).
4. An interrupt occurs.  The interrupt, as part of its processing, calls `sr_request_status_report()` to request a new status report.
5. `sr_request_status_report()` passes the initial check to ensure there's no existing sr request, since `sr.status_report_request` is equal to `SR_OFF` (being set as such immediately before the interrupt).
6. `sr_request_status_report()` sets the `sr.status_report_systick` timer to an appropriate value, and sets `sr.status_report_request` to something other than `SR_OFF` (normal behavior).
7. The interrupt returns, resuming `sr_status_report_callback()`.
8. `sr_status_report_callback()` calls `sr.status_report_systick.clear()`, clearing the timer for the next status report.
9. Now, `sr.status_report_systick` is cleared, and `sr.status_report_request` is set to a value other than `SR_OFF`.
10. Subsequent calls to `sr_request_status_report()` are no-ops, since that function bails immediately if `sr.status_report_request` is not `SR_OFF`.
11. Subsequent calls to `sr_status_report_callback()` are no-ops, since that function bails immediately if the sr timer in `sr.status_report_systick` has not passed, and the Motate `Timeout`'s `isPast()` method always returns false if the timer is cleared.
12. As such, no more status reports can be delivered, and there is no way for the system to recover from this state.

The fix for this particular race condition (without putting the timer clear and status_report_request clear within a critical section) is to clear the sr timer before setting `sr.status_report_request` to `SR_OFF`.  This way, if an interrupt occurs between these two instructions, the worst-case result is that `sr.status_report_systick` is "running" (ie, not cleared), but `sr.status_report_quest` is `SR_OFF`.  This condition, although technically still a "desync" of the status report request state, is not harmful, and is automatically resolved upon the next call to `sr_request_status_report()`.

Additionally, a related minor fix is included that prevented one-time verbose status report requests from working.  `sr_status_report_callback()` was setting `sr.status_report_request` to `SR_OFF` immediately before using it to check for the verbosity of the request.  This adds a temporary variable to hold this value.  (This was done instead of moving the sr building to ahead of state updates to ensure that status reports are still accurately fulfilled even in the case of an interrupt, as described above.)  A minor formatting issue in the same section of code was also fixed.