### PR TITLE
Config fixes for gShield/gquintic

### DIFF
--- a/g2core/board/gquintic.mk
+++ b/g2core/board/gquintic.mk
@@ -3,10 +3,10 @@
 
 
 # To compile:
-#   make BOARD=gquintic-a
+#   make BOARD=gquintic-d
 
 # You can also choose a CONFIG from boards.mk:
-#   make CONFIG=PrintrbotPlus BOARD=gquintic-b
+#   make CONFIG=PrintrbotPlus BOARD=gquintic-d
 
 
 ##########
@@ -25,16 +25,16 @@ ifeq ("$(BOARD)","gquintic-c")
 endif
 
 ifeq ("$(BOARD)","gquintic-d")
-BASE_BOARD=gquintic
-DEVICE_DEFINES += MOTATE_BOARD="gquintic-d"
-DEVICE_DEFINES += SETTINGS_FILE=${SETTINGS_FILE}
+    BASE_BOARD=gquintic
+    DEVICE_DEFINES += MOTATE_BOARD="gquintic-d"
+    DEVICE_DEFINES += SETTINGS_FILE=${SETTINGS_FILE}
 endif
 
 ifeq ("$(BOARD)","gquintic-g")
-BASE_BOARD=gquintic
-QUINTIC_N20=1
-DEVICE_DEFINES += MOTATE_BOARD="gquintic-d"
-DEVICE_DEFINES += SETTINGS_FILE=${SETTINGS_FILE}
+    BASE_BOARD=gquintic
+    QUINTIC_N20=1
+    DEVICE_DEFINES += MOTATE_BOARD="gquintic-d"
+    DEVICE_DEFINES += SETTINGS_FILE=${SETTINGS_FILE}
 endif
 
 ##########

--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -86,7 +86,7 @@
 #endif
 
 #ifndef SPINDLE_ENABLE_POLARITY
-#define SPINDLE_ENABLE_POLARITY     SPINDLE_ACTIVE_HIGH  // {spep: 0=active low, 1=active high
+#define SPINDLE_ENABLE_POLARITY     1  // {spep: 0=active low, 1=active high
 #endif
 
 #ifndef SPINDLE_DIR_POLARITY
@@ -116,6 +116,10 @@
 
 #ifndef SPINDLE_SPEED_MAX
 #define SPINDLE_SPEED_MAX     1000000.0     // {spsm:
+#endif
+
+#ifndef SPINDLE_SPEED_CHANGE_PER_MS
+#define SPINDLE_SPEED_CHANGE_PER_MS 10.0   // TODO
 #endif
 
 #ifndef COOLANT_MIST_POLARITY
@@ -259,7 +263,7 @@
 #define M1_ENABLE_POLARITY          IO_ACTIVE_LOW           // {1ep:  IO_ACTIVE_LOW or IO_ACTIVE_HIGH
 #endif
 #ifndef M1_STEP_POLARITY
-#define M1_STEP_POLARITY            IO_ACTIVE_HIGH          // {1ps:  IO_ACTIVE_LOW or IO_ACTIVE_HIGH
+#define M1_STEP_POLARITY            IO_ACTIVE_HIGH          // {1sp:  IO_ACTIVE_LOW or IO_ACTIVE_HIGH
 #endif
 #ifndef M1_POWER_MODE
 #define M1_POWER_MODE               MOTOR_DISABLED          // {1pm:  MOTOR_DISABLED, MOTOR_ALWAYS_POWERED, MOTOR_POWERED_IN_CYCLE, MOTOR_POWERED_ONLY_WHEN_MOVING


### PR DESCRIPTION
It looks like `SPINDLE_SPEED_CHANGE_PER_MS` isn't exposed as config but the other values in settings nearby are; I'm not sure if that's intentional or an oversight.

For purposes of making axes move, `gquintic-d` should be pretty similar to `gquintic-c`, right?