### PR TITLE
Fix bug with default spindle polarity value

### DIFF
--- a/g2core/settings/settings_default.h
+++ b/g2core/settings/settings_default.h
@@ -86,7 +86,7 @@
 #endif
 
 #ifndef SPINDLE_ENABLE_POLARITY
-#define SPINDLE_ENABLE_POLARITY     SPINDLE_ACTIVE_HIGH  // {spep: 0=active low, 1=active high
+#define SPINDLE_ENABLE_POLARITY     1       // 0=active low, 1=active high
 #endif
 
 #ifndef SPINDLE_DIR_POLARITY


### PR DESCRIPTION
This fixes an incorrect fallback value in the default settings, which leads to this error:

```
In file included from ./settings.h:59:0,
                 from ./board/gquintic/hardware.h:33,
                 from g2core.h:62,
                 from spindle.cpp:28:
./settings/settings_default.h:89:37: error: 'SPINDLE_ACTIVE_HIGH' was not declared in this scope
 #define SPINDLE_ENABLE_POLARITY     SPINDLE_ACTIVE_HIGH  // {spep: 0=active low, 1=active high
```

This error only occurs when the chosen settings file doesn't include a `SPINDLE_ENABLE_POLARITY` define, thus triggering the use of the no-longer-present `SPINDLE_ACTIVE_HIGH` one.